### PR TITLE
[feat] 일반 회원가입/로그인/로그아웃/탈되 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,11 @@ dependencies {
     // S3
     implementation 'software.amazon.awssdk:s3:2.20.26'
     implementation 'software.amazon.awssdk:url-connection-client:2.20.26'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/miruni/backend/domain/user/controller/AuthApi.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/AuthApi.java
@@ -1,0 +1,150 @@
+package com.miruni.backend.domain.user.controller;
+
+import com.miruni.backend.domain.user.dto.request.LoginRequest;
+import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.global.authroize.AuthToken;
+import com.miruni.backend.global.authroize.LoginUser;
+import com.miruni.backend.global.exception.CustomErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "인증 API", description = "로그인, 로그아웃 등 인증 관련 API")
+public interface AuthApi {
+
+    @Operation(
+            summary = "일반 로그인",
+            description = "이메일과 비밀번호로 로그인하고 JWT 토큰을 발급받습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.miruni.backend.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                            "errorCode": null,
+                            "message": "OK",
+                            "result": {
+                                "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+                                "refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+                                "tokenType": "Bearer",
+                                "accessTokenExpiresIn": 3600,
+                                "refreshTokenExpiresIn": 604800
+                            }
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "비밀번호가 올바르지 않음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "비밀번호 불일치",
+                                    value = """
+                        {
+                            "status": 400,
+                            "errorCode": "USER400_4",
+                            "message": "비밀번호가 올바르지 않습니다."
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "사용자 없음",
+                                    value = """
+                        {
+                            "status": 404,
+                            "errorCode": "USER404_3",
+                            "message": "사용자를 찾을 수 없습니다."
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "입력값 검증 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "검증 실패",
+                                    value = """
+                        {
+                            "status": 400,
+                            "errorCode": "COMMON_002",
+                            "message": "입력값 검증에 실패했습니다."
+                        }
+                        """
+                            )
+                    )
+            )
+    })
+    UserResponse login(@Valid @RequestBody LoginRequest request);
+
+    @Operation(
+            summary = "로그아웃",
+            description = "현재 사용자의 액세스 토큰을 블랙리스트에 추가하고 리프레시 토큰을 삭제합니다."
+    )
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "JWT")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.miruni.backend.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                            "errorCode": null,
+                            "message": "OK",
+                            "result": null
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "인증 실패",
+                                            summary = "JWT 토큰 인증 실패",
+                                            value = """
+                            {
+                                "status": 401,
+                                "errorCode": "COMMON_003",
+                                "message": "인증이 필요합니다."
+                            }
+                            """
+                                    ),
+                                    @ExampleObject(
+                                            name = "유효하지 않은 토큰",
+                                            summary = "액세스 토큰이 유효하지 않음",
+                                            value = """
+                            {
+                                "status": 401,
+                                "errorCode": "USER401_6",
+                                "message": "유효하지 않은 토큰입니다."
+                            }
+                            """
+                                    )
+                            }
+                    )
+            )
+    })
+    void logout(
+            @AuthToken String accessToken,
+            @LoginUser Long userId
+    );
+}

--- a/src/main/java/com/miruni/backend/domain/user/controller/AuthApi.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/AuthApi.java
@@ -1,7 +1,7 @@
 package com.miruni.backend.domain.user.controller;
 
 import com.miruni.backend.domain.user.dto.request.LoginRequest;
-import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
 import com.miruni.backend.global.authroize.AuthToken;
 import com.miruni.backend.global.authroize.LoginUser;
 import com.miruni.backend.global.exception.CustomErrorResponse;
@@ -90,7 +90,7 @@ public interface AuthApi {
                     )
             )
     })
-    UserResponse login(@Valid @RequestBody LoginRequest request);
+    JwtResponseDto login(@Valid @RequestBody LoginRequest request);
 
     @Operation(
             summary = "로그아웃",

--- a/src/main/java/com/miruni/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/AuthController.java
@@ -1,0 +1,34 @@
+package com.miruni.backend.domain.user.controller;
+
+import com.miruni.backend.domain.user.dto.request.LoginRequest;
+import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.service.AuthCommandService;
+import com.miruni.backend.global.authroize.AuthToken;
+import com.miruni.backend.global.authroize.LoginUser;
+import jakarta.validation.Valid;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Validated
+public class AuthController implements AuthApi {
+
+    private final AuthCommandService authCommandService;
+
+    // 일반 로그인 API
+    @PostMapping("/token")
+    public UserResponse login(@Valid @RequestBody LoginRequest request) {
+        return authCommandService.login(request);
+    }
+
+    // 일반 로그아웃 API
+    @DeleteMapping("/token")
+    public void logout(@AuthToken String accessToken, @LoginUser Long userId) {
+        authCommandService.logout(accessToken, userId);
+    }
+
+}

--- a/src/main/java/com/miruni/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.miruni.backend.domain.user.controller;
 
 import com.miruni.backend.domain.user.dto.request.LoginRequest;
-import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
 import com.miruni.backend.domain.user.service.AuthCommandService;
 import com.miruni.backend.global.authroize.AuthToken;
 import com.miruni.backend.global.authroize.LoginUser;
@@ -21,7 +21,7 @@ public class AuthController implements AuthApi {
 
     // 일반 로그인 API
     @PostMapping("/token")
-    public UserResponse login(@Valid @RequestBody LoginRequest request) {
+    public JwtResponseDto login(@Valid @RequestBody LoginRequest request) {
         return authCommandService.login(request);
     }
 

--- a/src/main/java/com/miruni/backend/domain/user/controller/SurveyApi.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/SurveyApi.java
@@ -1,0 +1,5 @@
+package com.miruni.backend.domain.user.controller;
+
+public interface SurveyApi {
+    
+}

--- a/src/main/java/com/miruni/backend/domain/user/controller/SurveyController.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/SurveyController.java
@@ -1,0 +1,5 @@
+package com.miruni.backend.domain.user.controller;
+
+public class SurveyController {
+    
+}

--- a/src/main/java/com/miruni/backend/domain/user/controller/UserApi.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/UserApi.java
@@ -1,0 +1,182 @@
+package com.miruni.backend.domain.user.controller;
+
+import com.miruni.backend.domain.user.dto.request.UserSignupRequest;
+import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.global.authroize.AuthToken;
+import com.miruni.backend.global.authroize.LoginUser;
+import com.miruni.backend.global.exception.CustomErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "사용자 API", description = "회원가입 등 사용자 관련 API")
+public interface UserApi {
+
+    @Operation(
+            summary = "일반 회원가입",
+            description = "이메일, 비밀번호, 닉네임으로 회원가입합니다. \n" +
+                    "이메일 중복 체크 후 비밀번호를 암호화하여 저장하고, \n" +
+                    "회원가입 성공 시 JWT 토큰을 발급합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.miruni.backend.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                            "errorCode": null,
+                            "message": "OK",
+                            "result": {
+                                "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+                                "refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+                                "tokenType": "Bearer",
+                                "accessTokenExpiresIn": 3600,
+                                "refreshTokenExpiresIn": 604800
+                            }
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "409", description = "중복된 이메일 또는 닉네임",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "이메일 중복",
+                                            summary = "이미 사용 중인 이메일",
+                                            value = """
+                            {
+                                "status": 409,
+                                "errorCode": "USER409_2",
+                                "message": "이미 사용 중인 이메일입니다."
+                            }
+                            """
+                                    ),
+                                    @ExampleObject(
+                                            name = "닉네임 중복",
+                                            summary = "이미 사용 중인 닉네임",
+                                            value = """
+                            {
+                                "status": 404,
+                                "errorCode": "USER404_1",
+                                "message": "이미 사용 중인 닉네임입니다."
+                            }
+                            """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "입력값 검증 실패 또는 필수 약관 미동의",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "입력값 검증 실패",
+                                            summary = "이메일, 비밀번호 형식 오류 등",
+                                            value = """
+                            {
+                                "status": 400,
+                                "errorCode": "COMMON_002",
+                                "message": "입력값 검증에 실패했습니다."
+                            }
+                            """
+                                    ),
+                                    @ExampleObject(
+                                            name = "필수 약관 미동의",
+                                            summary = "서비스 이용약관 동의 필수",
+                                            value = """
+                            {
+                                "status": 400,
+                                "errorCode": "USER400_5",
+                                "message": "필수 약관에 동의해야 합니다."
+                            }
+                            """
+                                    )
+                            }
+                    )
+            )
+    })
+    UserResponse signup(@Valid @RequestBody UserSignupRequest request);
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "현재 로그인한 사용자의 회원 탈퇴를 처리합니다. \n" +
+                    "소프트 삭제 방식으로 처리되며, 모든 토큰이 무효화됩니다."
+    )
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "JWT")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.miruni.backend.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                            "errorCode": null,
+                            "message": "OK",
+                            "result": null
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "이미 탈퇴한 사용자",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "이미 탈퇴한 사용자",
+                                    value = """
+                        {
+                            "status": 400,
+                            "errorCode": "USER400_7",
+                            "message": "이미 탈퇴한 사용자입니다."
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "인증 실패",
+                                    value = """
+                        {
+                            "status": 401,
+                            "errorCode": "COMMON_003",
+                            "message": "인증이 필요합니다."
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "사용자 없음",
+                                    value = """
+                        {
+                            "status": 404,
+                            "errorCode": "USER404_3",
+                            "message": "사용자를 찾을 수 없습니다."
+                        }
+                        """
+                            )
+                    )
+            )
+    })
+    void withdrawUser(
+            @AuthToken String accessToken,
+            @LoginUser Long userId
+    );
+}

--- a/src/main/java/com/miruni/backend/domain/user/controller/UserApi.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/UserApi.java
@@ -1,7 +1,7 @@
 package com.miruni.backend.domain.user.controller;
 
 import com.miruni.backend.domain.user.dto.request.UserSignupRequest;
-import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
 import com.miruni.backend.global.authroize.AuthToken;
 import com.miruni.backend.global.authroize.LoginUser;
 import com.miruni.backend.global.exception.CustomErrorResponse;
@@ -105,7 +105,7 @@ public interface UserApi {
                     )
             )
     })
-    UserResponse signup(@Valid @RequestBody UserSignupRequest request);
+    JwtResponseDto signup(@Valid @RequestBody UserSignupRequest request);
 
     @Operation(
             summary = "회원 탈퇴",

--- a/src/main/java/com/miruni/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/UserController.java
@@ -1,0 +1,50 @@
+package com.miruni.backend.domain.user.controller;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import com.miruni.backend.domain.user.dto.request.UserSignupRequest;
+import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.service.UserCommandService;
+import com.miruni.backend.global.authroize.AuthToken;
+import com.miruni.backend.global.authroize.LoginUser;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Validated
+public class UserController implements UserApi {
+
+    private final UserCommandService userCommandService;
+
+    // 일반 회원가입 API
+    @PostMapping
+    public UserResponse signup(@Valid @RequestBody UserSignupRequest request) {
+        return userCommandService.signup(request);
+    }
+
+    // 회원 탈퇴 API
+    @DeleteMapping("/me")
+    public void withdrawUser(@AuthToken String accessToken, @LoginUser Long userId) {
+        userCommandService.withdrawUser(accessToken, userId);
+    }
+
+    // TODO: 추후 구현 예정
+    // 이메일 인증 요청
+    // @PostMapping("/me/email-verification")
+
+    // TODO: 추후 구현 예정
+    // 내 정보 조회
+    // @GetMapping("/me")
+
+    // TODO: 추후 구현 예정
+    // 이메일 중복 확인
+    // @GetMapping("/email-duplicate")
+
+    // TODO: 추후 구현 예정
+    // 비밀번호 변경
+    // @PatchMapping("/me/password")
+}

--- a/src/main/java/com/miruni/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/UserController.java
@@ -4,7 +4,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import com.miruni.backend.domain.user.dto.request.UserSignupRequest;
-import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
 import com.miruni.backend.domain.user.service.UserCommandService;
 import com.miruni.backend.global.authroize.AuthToken;
 import com.miruni.backend.global.authroize.LoginUser;
@@ -22,7 +22,7 @@ public class UserController implements UserApi {
 
     // 일반 회원가입 API
     @PostMapping
-    public UserResponse signup(@Valid @RequestBody UserSignupRequest request) {
+    public JwtResponseDto signup(@Valid @RequestBody UserSignupRequest request) {
         return userCommandService.signup(request);
     }
 

--- a/src/main/java/com/miruni/backend/domain/user/dto/TokenDto.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/TokenDto.java
@@ -1,0 +1,21 @@
+package com.miruni.backend.domain.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TokenDto(
+        String accessToken,
+        String refreshToken,
+        long accessTokenExp,
+        long refreshTokenExp
+) {
+    public static TokenDto of(String accessToken, String refreshToken, long accessTokenExp, long refreshTokenExp) {
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExp(accessTokenExp)
+                .refreshTokenExp(refreshTokenExp)
+                .build();
+    }
+}
+

--- a/src/main/java/com/miruni/backend/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/request/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.miruni.backend.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "로그인 요청 DTO")
+public record LoginRequest(
+        
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Schema(description = "이메일", example = "dhzktldh@gmail.com")
+        String email,
+        
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Schema(description = "비밀번호", example = "tkddbs")
+        String password
+) {
+}
+

--- a/src/main/java/com/miruni/backend/domain/user/dto/request/UserSignupRequest.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/request/UserSignupRequest.java
@@ -1,0 +1,49 @@
+package com.miruni.backend.domain.user.dto.request;
+
+import com.miruni.backend.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UserSignupRequest(
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Size(max = 255, message = "이메일은 255자 이하여야 합니다.")
+        @Schema(description = "이메일 주소", example = "dhzktldh@gmail.com")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+        @Schema(description = "비밀번호", example = "password123!")
+        String password,
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 20, message = "닉네임은 20자 이하여야 합니다.")
+        @Schema(description = "사용자 닉네임", example = "추추")
+        String nickname,
+
+        @NotNull(message = "이용약관 동의는 필수입니다.")
+        @Schema(description = "이용약관 동의", example = "true")
+        Boolean serviceAgreed,
+
+        @NotNull(message = "개인정보 수집 및 이용 동의는 필수입니다.")
+        @Schema(description = "개인정보 수집 및 이용 동의", example = "true")
+        Boolean privacyAgreed,
+
+        @Schema(description = "마케팅 정보 수신 동의 (선택)", example = "false")
+        Boolean marketingAgreed
+
+) {
+        public User toEntity(String encodedPassword) {
+                return User.builder()
+                        .email(email)
+                        .password(encodedPassword)
+                        .nickname(nickname)
+                        .peanutCount(0)
+                        .oauthProvider(null)
+                        .build();
+        }
+}

--- a/src/main/java/com/miruni/backend/domain/user/dto/response/JwtResponseDto.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/response/JwtResponseDto.java
@@ -3,15 +3,15 @@ package com.miruni.backend.domain.user.dto.response;
 import lombok.Builder;
 
 @Builder
-public record UserResponse(
+public record JwtResponseDto(
     String accessToken,
     String refreshToken,
     String tokenType,
     Long accessTokenExpiresIn,
     Long refreshTokenExpiresIn
 ) {
-    public static UserResponse of(String accessToken, String refreshToken, long accessTokenExp, long refreshTokenExp) {
-        return UserResponse.builder()
+    public static JwtResponseDto of(String accessToken, String refreshToken, long accessTokenExp, long refreshTokenExp) {
+        return JwtResponseDto.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .tokenType("Bearer")

--- a/src/main/java/com/miruni/backend/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,22 @@
+package com.miruni.backend.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record UserResponse(
+    String accessToken,
+    String refreshToken,
+    String tokenType,
+    Long accessTokenExpiresIn,
+    Long refreshTokenExpiresIn
+) {
+    public static UserResponse of(String accessToken, String refreshToken, long accessTokenExp, long refreshTokenExp) {
+        return UserResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType("Bearer")
+                .accessTokenExpiresIn(accessTokenExp)
+                .refreshTokenExpiresIn(refreshTokenExp)
+                .build();
+    }
+} 

--- a/src/main/java/com/miruni/backend/domain/user/entity/Agreement.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/Agreement.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "agreement")
 public class Agreement extends BaseEntity {
@@ -32,5 +32,15 @@ public class Agreement extends BaseEntity {
     // 마케팅 동의 (true/false 수정 가능)
     @Column(name = "marketing_agreed")
     private Boolean marketingAgreed;
+
+    // 정적 팩토리 메서드
+    public static Agreement create(User user, Boolean serviceAgreed, Boolean privacyAgreed, Boolean marketingAgreed) {
+        return Agreement.builder()
+                .user(user)
+                .serviceAgreed(serviceAgreed != null ? serviceAgreed : false)
+                .privacyAgreed(privacyAgreed != null ? privacyAgreed : false)
+                .marketingAgreed(marketingAgreed != null ? marketingAgreed : false)
+                .build();
+    }
 
 }

--- a/src/main/java/com/miruni/backend/domain/user/entity/User.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/User.java
@@ -24,16 +24,16 @@ public class User extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(name = "name", nullable = false, length = 50)
+    @Column(name = "name", length = 50)
     private String name;
 
     @Column(name = "email", nullable = false, length = 255, unique = true)
     private String email;
 
-    @Column(name = "birth", nullable = false)
+    @Column(name = "birth")
     private LocalDate birth;
 
-    @Column(name = "phone_number", nullable = false, length = 30)
+    @Column(name = "phone_number", length = 30)
     private String phoneNumber;
 
     @Column(name = "password", nullable = false, length = 255)

--- a/src/main/java/com/miruni/backend/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/miruni/backend/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,24 @@
+package com.miruni.backend.domain.user.exception;
+
+import com.miruni.backend.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+    
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER404_1", "이미 사용 중인 닉네임입니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER409_2", "이미 사용 중인 이메일입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404_3", "사용자를 찾을 수 없습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER400_4", "비밀번호가 올바르지 않습니다."),
+    AGREEMENT_REQUIRED(HttpStatus.BAD_REQUEST, "USER400_5", "필수 약관에 동의해야 합니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "USER401_6", "유효하지 않은 토큰입니다."),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER400_7", "이미 탈퇴한 사용자입니다.");
+    
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}
+

--- a/src/main/java/com/miruni/backend/domain/user/repository/AgreementRepository.java
+++ b/src/main/java/com/miruni/backend/domain/user/repository/AgreementRepository.java
@@ -1,0 +1,10 @@
+package com.miruni.backend.domain.user.repository;
+
+import com.miruni.backend.domain.user.entity.Agreement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AgreementRepository extends JpaRepository<Agreement, Long> {
+}
+

--- a/src/main/java/com/miruni/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/miruni/backend/domain/user/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package com.miruni.backend.domain.user.repository;
+
+import com.miruni.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    
+    boolean existsByEmail(String email);
+    
+    boolean existsByNickname(String nickname);
+    
+    Optional<User> findByEmail(String email);
+}
+

--- a/src/main/java/com/miruni/backend/domain/user/service/AuthCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/AuthCommandService.java
@@ -1,0 +1,51 @@
+package com.miruni.backend.domain.user.service;
+
+import com.miruni.backend.domain.user.dto.request.LoginRequest;
+import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.entity.User;
+import com.miruni.backend.domain.user.exception.UserErrorCode;
+import com.miruni.backend.domain.user.repository.UserRepository;
+import com.miruni.backend.global.authroize.TokenService;
+import com.miruni.backend.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthCommandService {
+    
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenService tokenService;
+    
+    /**
+     * 일반 로그인
+     */
+    public UserResponse login(LoginRequest request) {
+        // 이메일로 사용자 조회
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
+        
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw BaseException.type(UserErrorCode.INVALID_PASSWORD);
+        }
+        
+        // 토큰 발급
+        log.info("로그인 성공: email={}, userId={}", request.email(), user.getId());
+        return tokenService.issueTokenResponse(user);
+    }
+
+    /**
+     *  일반 로그아웃
+     */
+    public void logout(String accessToken, Long userId) {
+        tokenService.logout(accessToken, userId);
+    }
+}
+

--- a/src/main/java/com/miruni/backend/domain/user/service/AuthCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/AuthCommandService.java
@@ -1,7 +1,7 @@
 package com.miruni.backend.domain.user.service;
 
 import com.miruni.backend.domain.user.dto.request.LoginRequest;
-import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
 import com.miruni.backend.domain.user.entity.User;
 import com.miruni.backend.domain.user.exception.UserErrorCode;
 import com.miruni.backend.domain.user.repository.UserRepository;
@@ -26,7 +26,7 @@ public class AuthCommandService {
     /**
      * 일반 로그인
      */
-    public UserResponse login(LoginRequest request) {
+    public JwtResponseDto login(LoginRequest request) {
         // 이메일로 사용자 조회
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
@@ -1,0 +1,86 @@
+package com.miruni.backend.domain.user.service;
+
+import com.miruni.backend.domain.user.dto.request.UserSignupRequest;
+import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.entity.Agreement;
+import com.miruni.backend.domain.user.entity.User;
+import com.miruni.backend.domain.user.exception.UserErrorCode;
+import com.miruni.backend.domain.user.repository.AgreementRepository;
+import com.miruni.backend.domain.user.repository.UserRepository;
+import com.miruni.backend.domain.user.validator.UserValidator;
+import com.miruni.backend.global.authroize.TokenService;
+import com.miruni.backend.global.exception.BaseException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserCommandService {
+    
+    private final UserRepository userRepository;
+    private final AgreementRepository agreementRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final UserValidator userValidator;
+    private final TokenService tokenService;
+    
+    /**
+     * 일반 회원가입
+     */
+    public UserResponse signup(UserSignupRequest request) {
+        // 이메일 중복 체크
+        userValidator.validateEmailNotExists(request.email());
+        
+        // 닉네임 중복 체크
+        userValidator.validateNicknameNotExists(request.nickname());
+        
+        // 필수 약관 동의 체크
+        userValidator.validateAgreements(request);
+        
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.password());
+        
+        // User 엔티티 생성 및 저장
+        User user = request.toEntity(encodedPassword);
+        userRepository.save(user);
+        
+        // Agreement 엔티티 생성 및 저장
+        Agreement agreement = Agreement.builder()
+                .user(user)
+                .serviceAgreed(request.serviceAgreed())
+                .privacyAgreed(request.privacyAgreed() != null ? request.privacyAgreed() : false)
+                .marketingAgreed(request.marketingAgreed() != null ? request.marketingAgreed() : false)
+                .build();
+        agreementRepository.save(agreement);
+        
+        // JWT 토큰 생성 및 반환
+        return tokenService.issueTokenResponse(user);
+    }
+
+    /**
+     * 회원 탈퇴
+     */
+    public void withdrawUser(String accessToken, Long userId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
+
+        // 이미 탈퇴한 사용자인지 확인
+        if (user.isDeleted()) {
+            throw BaseException.type(UserErrorCode.USER_ALREADY_DELETED);
+        }
+
+        // 소프트 삭제 처리
+        user.delete();
+
+        // 토큰 무효화 (로그아웃 처리)
+        tokenService.logout(accessToken, userId);
+
+        log.info("회원 탈퇴 완료: userId={}", userId);
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
@@ -1,7 +1,7 @@
 package com.miruni.backend.domain.user.service;
 
 import com.miruni.backend.domain.user.dto.request.UserSignupRequest;
-import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
 import com.miruni.backend.domain.user.entity.Agreement;
 import com.miruni.backend.domain.user.entity.User;
 import com.miruni.backend.domain.user.exception.UserErrorCode;
@@ -32,12 +32,12 @@ public class UserCommandService {
     /**
      * 일반 회원가입
      */
-    public UserResponse signup(UserSignupRequest request) {
+    public JwtResponseDto signup(UserSignupRequest request) {
         // 이메일 중복 체크
-        userValidator.validateEmailNotExists(request.email());
+        validateEmailNotExists(request.email());
         
         // 닉네임 중복 체크
-        userValidator.validateNicknameNotExists(request.nickname());
+        validateNicknameNotExists(request.nickname());
         
         // 필수 약관 동의 체크
         userValidator.validateAgreements(request);
@@ -50,16 +50,30 @@ public class UserCommandService {
         userRepository.save(user);
         
         // Agreement 엔티티 생성 및 저장
-        Agreement agreement = Agreement.builder()
-                .user(user)
-                .serviceAgreed(request.serviceAgreed())
-                .privacyAgreed(request.privacyAgreed() != null ? request.privacyAgreed() : false)
-                .marketingAgreed(request.marketingAgreed() != null ? request.marketingAgreed() : false)
-                .build();
+        Agreement agreement = Agreement.create(user, request.serviceAgreed(), request.privacyAgreed(), request.marketingAgreed());
         agreementRepository.save(agreement);
         
         // JWT 토큰 생성 및 반환
         return tokenService.issueTokenResponse(user);
+    }
+
+    /**
+     * 이메일 중복 검증
+     * - 데이터 접근이 필요한 검증은 서비스 계층에서 수행
+     */
+    private void validateEmailNotExists(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw BaseException.type(UserErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+    }
+
+    /**
+     * 닉네임 중복 검증
+     */
+    private void validateNicknameNotExists(String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw BaseException.type(UserErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
     }
 
     /**

--- a/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
@@ -57,9 +57,8 @@ public class UserCommandService {
         return tokenService.issueTokenResponse(user);
     }
 
-    /**
+    /** 
      * 이메일 중복 검증
-     * - 데이터 접근이 필요한 검증은 서비스 계층에서 수행
      */
     private void validateEmailNotExists(String email) {
         if (userRepository.existsByEmail(email)) {

--- a/src/main/java/com/miruni/backend/domain/user/validator/UserValidator.java
+++ b/src/main/java/com/miruni/backend/domain/user/validator/UserValidator.java
@@ -1,0 +1,44 @@
+package com.miruni.backend.domain.user.validator;
+
+import com.miruni.backend.domain.user.dto.request.UserSignupRequest;
+import com.miruni.backend.domain.user.exception.UserErrorCode;
+import com.miruni.backend.domain.user.repository.UserRepository;
+import com.miruni.backend.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserValidator {
+    
+    private final UserRepository userRepository;
+    
+    /**
+     * 이메일 중복 검증
+     */
+    public void validateEmailNotExists(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw BaseException.type(UserErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+    }
+    
+    /**
+     * 닉네임 중복 검증
+     */
+    public void validateNicknameNotExists(String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw BaseException.type(UserErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+    }
+    
+    /**
+     * 약관 동의 검증
+     */
+    public void validateAgreements(UserSignupRequest request) {
+        // 서비스 이용약관은 필수
+        if (request.serviceAgreed() == null || !request.serviceAgreed()) {
+            throw BaseException.type(UserErrorCode.AGREEMENT_REQUIRED);
+        }
+    }
+}
+

--- a/src/main/java/com/miruni/backend/domain/user/validator/UserValidator.java
+++ b/src/main/java/com/miruni/backend/domain/user/validator/UserValidator.java
@@ -2,7 +2,6 @@ package com.miruni.backend.domain.user.validator;
 
 import com.miruni.backend.domain.user.dto.request.UserSignupRequest;
 import com.miruni.backend.domain.user.exception.UserErrorCode;
-import com.miruni.backend.domain.user.repository.UserRepository;
 import com.miruni.backend.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -10,29 +9,10 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class UserValidator {
-    
-    private final UserRepository userRepository;
-    
-    /**
-     * 이메일 중복 검증
-     */
-    public void validateEmailNotExists(String email) {
-        if (userRepository.existsByEmail(email)) {
-            throw BaseException.type(UserErrorCode.EMAIL_ALREADY_EXISTS);
-        }
-    }
-    
-    /**
-     * 닉네임 중복 검증
-     */
-    public void validateNicknameNotExists(String nickname) {
-        if (userRepository.existsByNickname(nickname)) {
-            throw BaseException.type(UserErrorCode.NICKNAME_ALREADY_EXISTS);
-        }
-    }
-    
+
     /**
      * 약관 동의 검증
+     * - DB 접근이 필요 없는 순수 도메인/입력값 검증만 담당
      */
     public void validateAgreements(UserSignupRequest request) {
         // 서비스 이용약관은 필수
@@ -41,4 +21,3 @@ public class UserValidator {
         }
     }
 }
-

--- a/src/main/java/com/miruni/backend/domain/user/validator/UserValidator.java
+++ b/src/main/java/com/miruni/backend/domain/user/validator/UserValidator.java
@@ -12,7 +12,6 @@ public class UserValidator {
 
     /**
      * 약관 동의 검증
-     * - DB 접근이 필요 없는 순수 도메인/입력값 검증만 담당
      */
     public void validateAgreements(UserSignupRequest request) {
         // 서비스 이용약관은 필수

--- a/src/main/java/com/miruni/backend/global/authroize/AuthToken.java
+++ b/src/main/java/com/miruni/backend/global/authroize/AuthToken.java
@@ -1,0 +1,15 @@
+package com.miruni.backend.global.authroize;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Authorization 헤더에서 액세스 토큰을 추출하여 파라미터로 주입하는 어노테이션
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthToken {
+}
+

--- a/src/main/java/com/miruni/backend/global/authroize/AuthTokenArgumentResolver.java
+++ b/src/main/java/com/miruni/backend/global/authroize/AuthTokenArgumentResolver.java
@@ -1,0 +1,54 @@
+package com.miruni.backend.global.authroize;
+
+import com.miruni.backend.global.common.JwtUtil;
+import com.miruni.backend.global.exception.BaseException;
+import com.miruni.backend.global.exception.CommonErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * @AuthToken 어노테이션이 붙은 파라미터에 액세스 토큰을 자동으로 주입
+ * Authorization 헤더에서 "Bearer " 제거한 순수 토큰 반환
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthTokenArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // @AuthToken 어노테이션이 있고, String 타입인 경우 지원
+        return parameter.hasParameterAnnotation(AuthToken.class) 
+                && String.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        
+        String accessToken = jwtUtil.resolveToken(request);
+        
+        if (accessToken == null) {
+            log.warn("Authorization 헤더가 없거나 형식이 잘못됨");
+            throw BaseException.type(CommonErrorCode.UNAUTHORIZED);
+        }
+        
+        log.debug("@AuthToken 파라미터 주입: token={}", accessToken.substring(0, Math.min(20, accessToken.length())) + "...");
+        return accessToken;
+    }
+}
+

--- a/src/main/java/com/miruni/backend/global/authroize/CustomUserDetailService.java
+++ b/src/main/java/com/miruni/backend/global/authroize/CustomUserDetailService.java
@@ -1,0 +1,35 @@
+package com.miruni.backend.global.authroize;
+
+import com.miruni.backend.domain.user.entity.User;
+import com.miruni.backend.domain.user.exception.UserErrorCode;
+import com.miruni.backend.domain.user.repository.UserRepository;
+import com.miruni.backend.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
+        return new CustomUserDetails(user);
+    }
+
+    /**
+     * ID로 사용자 조회 (JWT 토큰 검증 시 사용)
+     */
+    public UserDetails loadUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
+        return new CustomUserDetails(user);
+    }
+}
+

--- a/src/main/java/com/miruni/backend/global/authroize/CustomUserDetails.java
+++ b/src/main/java/com/miruni/backend/global/authroize/CustomUserDetails.java
@@ -1,0 +1,59 @@
+package com.miruni.backend.global.authroize;
+
+import com.miruni.backend.domain.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public Long getId() {
+        return user.getId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 기본 권한 부여 (추후 Role 추가 시 수정)
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}
+

--- a/src/main/java/com/miruni/backend/global/authroize/LoginUser.java
+++ b/src/main/java/com/miruni/backend/global/authroize/LoginUser.java
@@ -1,0 +1,15 @@
+package com.miruni.backend.global.authroize;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 현재 인증된 사용자의 ID를 파라미터로 주입하는 어노테이션
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}
+

--- a/src/main/java/com/miruni/backend/global/authroize/LoginUserArgumentResolver.java
+++ b/src/main/java/com/miruni/backend/global/authroize/LoginUserArgumentResolver.java
@@ -1,0 +1,53 @@
+package com.miruni.backend.global.authroize;
+
+import com.miruni.backend.global.exception.BaseException;
+import com.miruni.backend.global.exception.CommonErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * @LoginUser 어노테이션이 붙은 파라미터에 현재 인증된 사용자 ID를 자동으로 주입
+ */
+@Slf4j
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // @LoginUser 어노테이션이 있고, Long 타입인 경우 지원
+        return parameter.hasParameterAnnotation(LoginUser.class) 
+                && Long.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        
+        if (authentication == null || !authentication.isAuthenticated()) {
+            log.warn("인증되지 않은 사용자의 @LoginUser 접근 시도");
+            throw BaseException.type(CommonErrorCode.UNAUTHORIZED);
+        }
+        
+        if (authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+            Long userId = userDetails.getId();
+            log.debug("@LoginUser 파라미터 주입: userId={}", userId);
+            return userId;
+        }
+        
+        log.error("CustomUserDetails 타입이 아닌 Principal: {}", authentication.getPrincipal().getClass());
+        throw BaseException.type(CommonErrorCode.UNAUTHORIZED);
+    }
+}
+

--- a/src/main/java/com/miruni/backend/global/authroize/TokenService.java
+++ b/src/main/java/com/miruni/backend/global/authroize/TokenService.java
@@ -1,0 +1,121 @@
+package com.miruni.backend.global.authroize;
+
+import com.miruni.backend.domain.user.dto.TokenDto;
+import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.entity.User;
+import com.miruni.backend.global.common.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
+    private static final String BLACKLIST_PREFIX = "blacklist:";
+
+    /**
+     * 공통 토큰 발급/저장 메서드
+     */
+    private TokenDto createAndStoreTokens(User user) {
+        Authentication authentication = createAuthentication(user);
+        TokenDto tokenDto = jwtUtil.createTokenDto(authentication);
+
+        saveRefreshToken(user.getId().toString(), tokenDto.refreshToken(), tokenDto.refreshTokenExp());
+
+        return tokenDto;
+    }
+
+    /**
+     * 회원가입/로그인 시 토큰 응답 생성
+     */
+    public UserResponse issueTokenResponse(User user) {
+        TokenDto token = createAndStoreTokens(user);
+        return UserResponse.of(
+                token.accessToken(),
+                token.refreshToken(),
+                token.accessTokenExp(),
+                token.refreshTokenExp()
+        );
+    }
+
+    /**
+     * 인증 객체 생성
+     */
+    private Authentication createAuthentication(User user) {
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        return new UsernamePasswordAuthenticationToken(
+                userDetails, null, userDetails.getAuthorities());
+    }
+
+    /**
+     * 리프레시 토큰을 Redis에 저장
+     */
+    private void saveRefreshToken(String userId, String refreshToken, long expirationTimeInSeconds) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        redisTemplate.opsForValue().set(key, refreshToken, Duration.ofSeconds(expirationTimeInSeconds));
+        log.info("리프레시 토큰 저장됨: userId={}", userId);
+    }
+
+    /**
+     * 리프레시 토큰 조회
+     */
+    public String getRefreshToken(String userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    /**
+     * 리프레시 토큰 삭제
+     */
+    public void deleteRefreshToken(String userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        redisTemplate.delete(key);
+        log.info("리프레시 토큰 삭제됨: userId={}", userId);
+    }
+
+    /**
+     * 액세스 토큰을 블랙리스트에 추가 (로그아웃 시)
+     */
+    public void addToBlacklist(String token, long expirationTimeInSeconds) {
+        String key = BLACKLIST_PREFIX + token;
+        redisTemplate.opsForValue().set(key, "blacklisted", Duration.ofSeconds(expirationTimeInSeconds));
+        log.info("토큰이 블랙리스트에 추가됨");
+    }
+
+    /**
+     * 토큰이 블랙리스트에 있는지 확인
+     */
+    public boolean isTokenBlacklisted(String token) {
+        String key = BLACKLIST_PREFIX + token;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    /**
+     * 로그아웃 처리
+     * - 현재 액세스 토큰을 블랙리스트에 추가
+     * - Redis에서 리프레시 토큰 삭제
+     */
+    public void logout(String accessToken, Long userId) {
+        // 액세스 토큰 블랙리스트 등록
+        long remainingTime = jwtUtil.getRemainingTimeInSeconds(accessToken);
+        addToBlacklist(accessToken, remainingTime);
+        
+        // 리프레시 토큰 삭제
+        deleteRefreshToken(userId.toString());
+        
+        log.info("로그아웃 완료: userId={}", userId);
+    }
+}
+

--- a/src/main/java/com/miruni/backend/global/authroize/TokenService.java
+++ b/src/main/java/com/miruni/backend/global/authroize/TokenService.java
@@ -1,15 +1,13 @@
 package com.miruni.backend.global.authroize;
 
-import com.miruni.backend.domain.user.dto.TokenDto;
-import com.miruni.backend.domain.user.dto.response.UserResponse;
+import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
 import com.miruni.backend.domain.user.entity.User;
 import com.miruni.backend.global.common.JwtUtil;
+import com.miruni.backend.global.common.TokenDto;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -29,10 +27,10 @@ public class TokenService {
      * 공통 토큰 발급/저장 메서드
      */
     private TokenDto createAndStoreTokens(User user) {
-        Authentication authentication = createAuthentication(user);
-        TokenDto tokenDto = jwtUtil.createTokenDto(authentication);
+        Long userId = user.getId();
+        TokenDto tokenDto = jwtUtil.createTokenDto(userId);
 
-        saveRefreshToken(user.getId().toString(), tokenDto.refreshToken(), tokenDto.refreshTokenExp());
+        saveRefreshToken(userId.toString(), tokenDto.refreshToken(), tokenDto.refreshTokenExp());
 
         return tokenDto;
     }
@@ -40,23 +38,14 @@ public class TokenService {
     /**
      * 회원가입/로그인 시 토큰 응답 생성
      */
-    public UserResponse issueTokenResponse(User user) {
+    public JwtResponseDto issueTokenResponse(User user) {
         TokenDto token = createAndStoreTokens(user);
-        return UserResponse.of(
+        return JwtResponseDto.of(
                 token.accessToken(),
                 token.refreshToken(),
                 token.accessTokenExp(),
                 token.refreshTokenExp()
         );
-    }
-
-    /**
-     * 인증 객체 생성
-     */
-    private Authentication createAuthentication(User user) {
-        CustomUserDetails userDetails = new CustomUserDetails(user);
-        return new UsernamePasswordAuthenticationToken(
-                userDetails, null, userDetails.getAuthorities());
     }
 
     /**

--- a/src/main/java/com/miruni/backend/global/common/BaseEntity.java
+++ b/src/main/java/com/miruni/backend/global/common/BaseEntity.java
@@ -22,4 +22,17 @@ public abstract class BaseEntity {
     @LastModifiedDate
     protected LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    // 소프트 삭제 여부 확인
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    // 소프트 삭제 처리
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/miruni/backend/global/common/JwtUtil.java
+++ b/src/main/java/com/miruni/backend/global/common/JwtUtil.java
@@ -1,0 +1,198 @@
+package com.miruni.backend.global.common;
+
+import com.miruni.backend.domain.user.dto.TokenDto;
+import com.miruni.backend.global.authroize.CustomUserDetails;
+import com.miruni.backend.global.exception.BaseException;
+import com.miruni.backend.global.exception.CommonErrorCode;
+import com.miruni.backend.global.properties.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import jakarta.servlet.http.HttpServletRequest; // Spring Boot 3 기준 (부트2면 javax.servlet로 변경)
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private final JwtProperties jwtProperties;
+
+    // --- 토큰 타입 상수 & 클레임 키 ---
+    private static final String CLAIM_TOKEN_TYPE = "type";
+    private static final String TOKEN_TYPE_ACCESS = "ACCESS";
+    private static final String TOKEN_TYPE_REFRESH = "REFRESH";
+    private static final String TOKEN_TYPE_TEMP = "TEMP";
+
+    // 이메일 인증 등에서 사용할 임시 토큰 만료시간 (고정)
+    private static final long TEMP_TOKEN_EXPIRATION = 1000L * 60 * 5; // 5분
+
+    // ===== 공통 내부 로직 =====
+
+    private SecretKey getSigningKey() {
+        byte[] keyBytes = jwtProperties.secret().getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    private Long extractUserId(Authentication authentication) {
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getId();
+    }
+
+    private String generateToken(Long userId, String tokenType, long validityMs) {
+        long now = System.currentTimeMillis();
+        Date issuedAt = new Date(now);
+        Date expiresAt = new Date(now + validityMs);    
+
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim(CLAIM_TOKEN_TYPE, tokenType)
+                .issuedAt(issuedAt)
+                .expiration(expiresAt)
+                .signWith(getSigningKey(), Jwts.SIG.HS512)
+                .compact();
+    }
+
+    // ===== 토큰 생성 =====
+
+    /** Access Token 생성 */
+    public String generateAccessToken(Authentication authentication) {
+        Long userId = extractUserId(authentication);
+        return generateToken(userId, TOKEN_TYPE_ACCESS, jwtProperties.accessTokenExpiration());
+    }
+
+    /** Refresh Token 생성 */
+    public String generateRefreshToken(Authentication authentication) {
+        Long userId = extractUserId(authentication);
+        return generateToken(userId, TOKEN_TYPE_REFRESH, jwtProperties.refreshTokenExpiration());
+    }
+
+    /** 임시 토큰 생성 (이메일 인증 등에 사용) */
+    public String generateTempToken(Authentication authentication) {
+        Long userId = extractUserId(authentication);
+        return generateToken(userId, TOKEN_TYPE_TEMP, TEMP_TOKEN_EXPIRATION);
+    }
+
+    /** Access + Refresh 한 번에 생성해서 DTO로 리턴 */
+    public TokenDto createTokenDto(Authentication authentication) {
+        String accessToken = generateAccessToken(authentication);
+        String refreshToken = generateRefreshToken(authentication);
+
+        long accessTokenExp = getAccessTokenExpirationInSeconds();
+        long refreshTokenExp = getRefreshTokenExpirationInSeconds();
+
+        return TokenDto.of(accessToken, refreshToken, accessTokenExp, refreshTokenExp);
+    }
+
+    // ===== 만료 관련 유틸 =====
+
+    public long getAccessTokenExpirationInSeconds() {
+        return jwtProperties.accessTokenExpiration() / 1000;
+    }
+
+    public long getRefreshTokenExpirationInSeconds() {
+        return jwtProperties.refreshTokenExpiration() / 1000;
+    }
+
+    /** 토큰의 남은 유효 시간 (초 단위) */
+    public long getRemainingTimeInSeconds(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            Date expiration = claims.getExpiration();
+            if (expiration == null) {
+                return 0;
+            }
+
+            long remainingTime = expiration.getTime() - System.currentTimeMillis();
+            return Math.max(0, remainingTime / 1000);
+        } catch (Exception e) {
+            log.warn("토큰 남은 시간 계산 실패: {}", e.getMessage());
+            return 0;
+        }
+    }
+
+    // ===== 검증 / 파싱 =====
+
+    /** 토큰 검증 (서명 + 만료) */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            log.warn("JWT 토큰 검증 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /** 토큰에서 사용자 ID 추출 (실패 시 UNAUTHORIZED 예외) */
+    public Long getUserIdFromToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            return Long.parseLong(claims.getSubject());
+        } catch (Exception e) {
+            log.error("토큰에서 사용자 ID 추출 실패: {}", e.getMessage());
+            throw BaseException.type(CommonErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    /** 토큰 타입(ACCESS/REFRESH/TEMP) 추출 */
+    public String getTokenType(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            return claims.get(CLAIM_TOKEN_TYPE, String.class);
+        } catch (Exception e) {
+            log.warn("토큰 타입 추출 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public boolean isAccessToken(String token) {
+        return TOKEN_TYPE_ACCESS.equals(getTokenType(token));
+    }
+
+    public boolean isRefreshToken(String token) {
+        return TOKEN_TYPE_REFRESH.equals(getTokenType(token));
+    }
+
+    public boolean isTempToken(String token) {
+        return TOKEN_TYPE_TEMP.equals(getTokenType(token));
+    }
+
+    // ===== HTTP 요청에서 토큰 꺼내는 헬퍼 =====
+
+    /**
+     * Authorization 헤더에서 Bearer 토큰 추출
+     */
+    public String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/miruni/backend/global/common/JwtUtil.java
+++ b/src/main/java/com/miruni/backend/global/common/JwtUtil.java
@@ -1,7 +1,5 @@
 package com.miruni.backend.global.common;
 
-import com.miruni.backend.domain.user.dto.TokenDto;
-import com.miruni.backend.global.authroize.CustomUserDetails;
 import com.miruni.backend.global.exception.BaseException;
 import com.miruni.backend.global.exception.CommonErrorCode;
 import com.miruni.backend.global.properties.JwtProperties;
@@ -10,11 +8,10 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
-import jakarta.servlet.http.HttpServletRequest; // Spring Boot 3 기준 (부트2면 javax.servlet로 변경)
+import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
@@ -31,19 +28,11 @@ public class JwtUtil {
     private static final String TOKEN_TYPE_REFRESH = "REFRESH";
     private static final String TOKEN_TYPE_TEMP = "TEMP";
 
-    // 이메일 인증 등에서 사용할 임시 토큰 만료시간 (고정)
-    private static final long TEMP_TOKEN_EXPIRATION = 1000L * 60 * 5; // 5분
-
     // ===== 공통 내부 로직 =====
 
     private SecretKey getSigningKey() {
         byte[] keyBytes = jwtProperties.secret().getBytes(StandardCharsets.UTF_8);
         return Keys.hmacShaKeyFor(keyBytes);
-    }
-
-    private Long extractUserId(Authentication authentication) {
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        return userDetails.getId();
     }
 
     private String generateToken(Long userId, String tokenType, long validityMs) {
@@ -63,27 +52,24 @@ public class JwtUtil {
     // ===== 토큰 생성 =====
 
     /** Access Token 생성 */
-    public String generateAccessToken(Authentication authentication) {
-        Long userId = extractUserId(authentication);
+    public String generateAccessToken(Long userId) {
         return generateToken(userId, TOKEN_TYPE_ACCESS, jwtProperties.accessTokenExpiration());
     }
 
     /** Refresh Token 생성 */
-    public String generateRefreshToken(Authentication authentication) {
-        Long userId = extractUserId(authentication);
+    public String generateRefreshToken(Long userId) {
         return generateToken(userId, TOKEN_TYPE_REFRESH, jwtProperties.refreshTokenExpiration());
     }
 
     /** 임시 토큰 생성 (이메일 인증 등에 사용) */
-    public String generateTempToken(Authentication authentication) {
-        Long userId = extractUserId(authentication);
-        return generateToken(userId, TOKEN_TYPE_TEMP, TEMP_TOKEN_EXPIRATION);
+    public String generateTempToken(Long userId) {
+        return generateToken(userId, TOKEN_TYPE_TEMP, jwtProperties.tempTokenExpiration());
     }
 
     /** Access + Refresh 한 번에 생성해서 DTO로 리턴 */
-    public TokenDto createTokenDto(Authentication authentication) {
-        String accessToken = generateAccessToken(authentication);
-        String refreshToken = generateRefreshToken(authentication);
+    public TokenDto createTokenDto(Long userId) {
+        String accessToken = generateAccessToken(userId);
+        String refreshToken = generateRefreshToken(userId);
 
         long accessTokenExp = getAccessTokenExpirationInSeconds();
         long refreshTokenExp = getRefreshTokenExpirationInSeconds();
@@ -104,11 +90,7 @@ public class JwtUtil {
     /** 토큰의 남은 유효 시간 (초 단위) */
     public long getRemainingTimeInSeconds(String token) {
         try {
-            Claims claims = Jwts.parser()
-                    .verifyWith(getSigningKey())
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload();
+            Claims claims = parseClaims(token);
 
             Date expiration = claims.getExpiration();
             if (expiration == null) {
@@ -125,13 +107,24 @@ public class JwtUtil {
 
     // ===== 검증 / 파싱 =====
 
+    /** 토큰에서 Claims 전체를 파싱 */
+    public Claims parseClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (Exception e) {
+            log.warn("JWT Claims 파싱 실패: {}", e.getMessage());
+            throw BaseException.type(CommonErrorCode.UNAUTHORIZED);
+        }
+    }
+
     /** 토큰 검증 (서명 + 만료) */
     public boolean validateToken(String token) {
         try {
-            Jwts.parser()
-                    .verifyWith(getSigningKey())
-                    .build()
-                    .parseSignedClaims(token);
+            parseClaims(token);
             return true;
         } catch (Exception e) {
             log.warn("JWT 토큰 검증 실패: {}", e.getMessage());
@@ -142,12 +135,7 @@ public class JwtUtil {
     /** 토큰에서 사용자 ID 추출 (실패 시 UNAUTHORIZED 예외) */
     public Long getUserIdFromToken(String token) {
         try {
-            Claims claims = Jwts.parser()
-                    .verifyWith(getSigningKey())
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload();
-
+            Claims claims = parseClaims(token);
             return Long.parseLong(claims.getSubject());
         } catch (Exception e) {
             log.error("토큰에서 사용자 ID 추출 실패: {}", e.getMessage());
@@ -158,12 +146,7 @@ public class JwtUtil {
     /** 토큰 타입(ACCESS/REFRESH/TEMP) 추출 */
     public String getTokenType(String token) {
         try {
-            Claims claims = Jwts.parser()
-                    .verifyWith(getSigningKey())
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload();
-
+            Claims claims = parseClaims(token);
             return claims.get(CLAIM_TOKEN_TYPE, String.class);
         } catch (Exception e) {
             log.warn("토큰 타입 추출 실패: {}", e.getMessage());

--- a/src/main/java/com/miruni/backend/global/common/TokenDto.java
+++ b/src/main/java/com/miruni/backend/global/common/TokenDto.java
@@ -1,4 +1,4 @@
-package com.miruni.backend.domain.user.dto;
+package com.miruni.backend.global.common;
 
 import lombok.Builder;
 

--- a/src/main/java/com/miruni/backend/global/config/JwtFilter.java
+++ b/src/main/java/com/miruni/backend/global/config/JwtFilter.java
@@ -1,0 +1,73 @@
+package com.miruni.backend.global.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.miruni.backend.global.authroize.CustomUserDetailService;
+import com.miruni.backend.global.authroize.TokenService;
+import com.miruni.backend.global.common.JwtUtil;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+    
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailService customUserDetailService;
+    private final TokenService tokenService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) 
+            throws ServletException, IOException {
+        
+        String token = jwtUtil.resolveToken(request);
+        
+        if (token != null) {
+            try {
+                if (jwtUtil.validateToken(token)) {
+                    
+                    // 블랙리스트 체크
+                    if (tokenService.isTokenBlacklisted(token)) {
+                        log.warn("블랙리스트된 토큰 사용 시도");
+                        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                        return;
+                    }
+                    
+                    Long userId = jwtUtil.getUserIdFromToken(token);
+                    
+                    // 임시 토큰인지 확인
+                    String tokenType = jwtUtil.getTokenType(token);
+                    if ("temp".equals(tokenType)) {
+                        log.debug("임시 토큰 사용: userId={}", userId);
+                    }
+                    
+                    UserDetails userDetails = customUserDetailService.loadUserById(userId);
+                    
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(
+                                    userDetails, null, userDetails.getAuthorities());
+                    
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    
+                    log.debug("JWT 토큰 검증 성공: userId={}", userId);
+                }
+            } catch (Exception e) {
+                log.warn("JWT 토큰 검증 실패: {}", e.getMessage());
+            }
+        }
+        
+        filterChain.doFilter(request, response);
+    }
+}
+

--- a/src/main/java/com/miruni/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/miruni/backend/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.miruni.backend.global.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -7,11 +8,17 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -29,12 +36,17 @@ public class SecurityConfig {
                 //http Basic 인증 비활성화 - jwt 구현 전 임시 활성화
                 //.httpBasic(AbstractHttpConfigurer::disable)
 
+                // JWT 필터 추가
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+
                 //URL별 권한 설정
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers(
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/actuator/**"
+                                "/actuator/**",
+                                "/api/users", // 회원가입 API
+                                "/api/auth/token" // 로그인 API
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
@@ -42,5 +54,10 @@ public class SecurityConfig {
 
         return http.build();
 
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/miruni/backend/global/config/WebConfig.java
+++ b/src/main/java/com/miruni/backend/global/config/WebConfig.java
@@ -1,0 +1,29 @@
+package com.miruni.backend.global.config;
+
+import com.miruni.backend.global.authroize.AuthTokenArgumentResolver;
+import com.miruni.backend.global.authroize.LoginUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+/**
+ * Spring MVC 설정
+ * - 커스텀 ArgumentResolver 등록
+ */
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+    private final AuthTokenArgumentResolver authTokenArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver);
+        resolvers.add(authTokenArgumentResolver);
+    }
+}
+

--- a/src/main/java/com/miruni/backend/global/properties/JwtProperties.java
+++ b/src/main/java/com/miruni/backend/global/properties/JwtProperties.java
@@ -1,0 +1,12 @@
+package com.miruni.backend.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        Long accessTokenExpiration,
+        Long refreshTokenExpiration
+) {
+}
+

--- a/src/main/java/com/miruni/backend/global/properties/JwtProperties.java
+++ b/src/main/java/com/miruni/backend/global/properties/JwtProperties.java
@@ -6,7 +6,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record JwtProperties(
         String secret,
         Long accessTokenExpiration,
-        Long refreshTokenExpiration
+        Long refreshTokenExpiration,
+        Long tempTokenExpiration
 ) {
 }
 

--- a/src/main/java/com/miruni/backend/global/response/GlobalResponseAdvice.java
+++ b/src/main/java/com/miruni/backend/global/response/GlobalResponseAdvice.java
@@ -45,3 +45,5 @@ public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
 
     }
 }
+
+// 지금 ResponseEntity<CustomErrorResponse>는 래핑되지 않는 것 같은데 실패 응답도 성공이랑 동일하게 가져갈까?

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/miruni
     username: root
-    password: tkddbs3535
+    password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -15,6 +15,11 @@ spring:
     hibernate:
       ddl-auto: create
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 management:
   endpoints:
     web:
@@ -23,3 +28,8 @@ management:
   endpoint:
     health:
       show-details: always
+
+jwt:
+  secret: 5aedd2efbda1ac3267a4b4f3e76ae712a1efcbbaf75fbf6f2b1332fa948ff3e9e2b09ce5de6d102a81b11d48b7cc951b64b7d785effc985eee75fcac4d1b99ea
+  access-token-expiration: 3600000      
+  refresh-token-expiration: 604800000   

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,4 +32,5 @@ management:
 jwt:
   secret: 5aedd2efbda1ac3267a4b4f3e76ae712a1efcbbaf75fbf6f2b1332fa948ff3e9e2b09ce5de6d102a81b11d48b7cc951b64b7d785effc985eee75fcac4d1b99ea
   access-token-expiration: 3600000      
-  refresh-token-expiration: 604800000   
+  refresh-token-expiration: 604800000
+  temp-token-expiration: 300000  


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #7 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 일반 회원가입 
- 일반 로그인
- 로그아웃
- 탈퇴 API 구현

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->

- jwt 설정 값(비밀키, 만료시간)을 코드에서 떼어내서 yml/properties 로 뺐습니다
- 나머지는 이전과 비슷하게 구현했고 Argument Resolver만 추가로 사용해서 자동으로 값들 주입되도록 수정했습니다
- 로그인 과정에서 이름, 생년월일, 전화번호 필수가 아닌 줄 알고 뺐는데 나눠져 있는 회원가입 로직1,2를 하나로 통일한다고 하네요 디자인 다시 나오는 대로 바로 수정하겠습니다
