### PR TITLE
[feat] 고객센터 관련 API 구현

### DIFF
--- a/src/main/java/com/miruni/backend/domain/question/controller/QuestionApi.java
+++ b/src/main/java/com/miruni/backend/domain/question/controller/QuestionApi.java
@@ -1,0 +1,16 @@
+package com.miruni.backend.domain.question.controller;
+
+import com.miruni.backend.domain.question.dto.request.SaveQuestionRequestDto;
+import com.miruni.backend.domain.question.dto.response.QuestionResponseDto;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface QuestionApi {
+
+    QuestionResponseDto save(
+            @Valid @RequestPart("request") SaveQuestionRequestDto saveQuestionRequestDto,
+            @RequestPart(value = "question_images", required = false) List<MultipartFile> questionImages);
+}

--- a/src/main/java/com/miruni/backend/domain/question/controller/QuestionApi.java
+++ b/src/main/java/com/miruni/backend/domain/question/controller/QuestionApi.java
@@ -1,16 +1,70 @@
 package com.miruni.backend.domain.question.controller;
 
 import com.miruni.backend.domain.question.dto.request.SaveQuestionRequestDto;
+import com.miruni.backend.domain.question.dto.request.UpdateQuestionRequestDto;
+import com.miruni.backend.domain.question.dto.response.GetListQuestionResponseDto;
+import com.miruni.backend.domain.question.dto.response.GetQuestionResponseDto;
 import com.miruni.backend.domain.question.dto.response.QuestionCommandResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+@Tag(name = "Question", description = "문의 관련 API")
 public interface QuestionApi {
 
+    @Operation(
+            summary = "문의 생성",
+            description = "문의 생성 API 입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "문의 등록 성공"),
+            @ApiResponse(responseCode = "500", description = "업로드 실패"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
     QuestionCommandResponseDto save(
             @Valid @RequestPart("request") SaveQuestionRequestDto saveQuestionRequestDto,
             @RequestPart(value = "question_images", required = false) List<MultipartFile> questionImages);
+
+    @Operation(
+            summary = "문의 업데이트",
+            description = "문의 업데이트 API 입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "문의 업데이트 성공"),
+            @ApiResponse(responseCode = "500", description = "업로드 실패"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    QuestionCommandResponseDto update(
+            @Valid @RequestPart("request") UpdateQuestionRequestDto request,
+            @RequestPart(value = "questionImages", required = false)List<MultipartFile> questionImages,
+            @PathVariable Long questionId
+    );
+
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "문의 리스트 조회 성공"),
+    })
+    @Operation(
+            summary = "문의 리스트 조회",
+            description = "문의 리스트 조회 API 입니다."
+    )
+    GetListQuestionResponseDto getListQuestion();
+
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "문의 상세 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @Operation(
+            summary = "문의 개별 조회",
+            description = "문의 개별조회 API 입니다."
+    )
+    GetQuestionResponseDto getQuestion(@PathVariable Long questionId);
 }
+
+

--- a/src/main/java/com/miruni/backend/domain/question/controller/QuestionApi.java
+++ b/src/main/java/com/miruni/backend/domain/question/controller/QuestionApi.java
@@ -1,7 +1,7 @@
 package com.miruni.backend.domain.question.controller;
 
 import com.miruni.backend.domain.question.dto.request.SaveQuestionRequestDto;
-import com.miruni.backend.domain.question.dto.response.QuestionResponseDto;
+import com.miruni.backend.domain.question.dto.response.QuestionCommandResponseDto;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface QuestionApi {
 
-    QuestionResponseDto save(
+    QuestionCommandResponseDto save(
             @Valid @RequestPart("request") SaveQuestionRequestDto saveQuestionRequestDto,
             @RequestPart(value = "question_images", required = false) List<MultipartFile> questionImages);
 }

--- a/src/main/java/com/miruni/backend/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/miruni/backend/domain/question/controller/QuestionController.java
@@ -4,8 +4,11 @@ import com.miruni.backend.domain.question.dto.command.SaveQuestionCommandDto;
 import com.miruni.backend.domain.question.dto.command.UpdateQuestionCommandDto;
 import com.miruni.backend.domain.question.dto.request.SaveQuestionRequestDto;
 import com.miruni.backend.domain.question.dto.request.UpdateQuestionRequestDto;
+import com.miruni.backend.domain.question.dto.response.GetListQuestionResponseDto;
 import com.miruni.backend.domain.question.dto.response.QuestionCommandResponseDto;
+import com.miruni.backend.domain.question.dto.response.GetQuestionResponseDto;
 import com.miruni.backend.domain.question.service.QuestionCommandService;
+import com.miruni.backend.domain.question.service.QuestionQueryService;
 import com.miruni.backend.global.annotation.SwaggerBody;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;
@@ -23,6 +26,7 @@ import java.util.List;
 public class QuestionController implements QuestionApi {
 
     private final QuestionCommandService questionCommandService;
+    private final QuestionQueryService questionQueryService;
 
     @SwaggerBody(content = @Content(
             encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)))
@@ -44,5 +48,17 @@ public class QuestionController implements QuestionApi {
             @PathVariable Long questionId
     ){
         return questionCommandService.update(UpdateQuestionCommandDto.of(request, questionImages, questionId));
+    }
+
+    @GetMapping
+    public GetListQuestionResponseDto getListQuestion(){
+        return questionQueryService.getListQuestion();
+    }
+
+    @GetMapping("/{questionId}")
+    public GetQuestionResponseDto getQuestion(
+            @PathVariable Long questionId
+    ){
+        return questionQueryService.getQuestion(questionId);
     }
 }

--- a/src/main/java/com/miruni/backend/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/miruni/backend/domain/question/controller/QuestionController.java
@@ -1,0 +1,32 @@
+package com.miruni.backend.domain.question.controller;
+
+import com.miruni.backend.domain.question.dto.command.SaveQuestionCommandDto;
+import com.miruni.backend.domain.question.dto.request.SaveQuestionRequestDto;
+import com.miruni.backend.domain.question.dto.response.QuestionResponseDto;
+import com.miruni.backend.domain.question.service.QuestionCommandService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/questions")
+public class QuestionController implements QuestionApi {
+
+    private final QuestionCommandService questionCommandService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public QuestionResponseDto save(
+            @Valid @RequestPart("request") SaveQuestionRequestDto saveQuestionRequestDto,
+            @RequestPart(value = "question_images", required = false)List<MultipartFile> questionImages) {
+
+        return questionCommandService.save(SaveQuestionCommandDto.of(saveQuestionRequestDto, questionImages));
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/miruni/backend/domain/question/controller/QuestionController.java
@@ -1,16 +1,18 @@
 package com.miruni.backend.domain.question.controller;
 
 import com.miruni.backend.domain.question.dto.command.SaveQuestionCommandDto;
+import com.miruni.backend.domain.question.dto.command.UpdateQuestionCommandDto;
 import com.miruni.backend.domain.question.dto.request.SaveQuestionRequestDto;
-import com.miruni.backend.domain.question.dto.response.QuestionResponseDto;
+import com.miruni.backend.domain.question.dto.request.UpdateQuestionRequestDto;
+import com.miruni.backend.domain.question.dto.response.QuestionCommandResponseDto;
 import com.miruni.backend.domain.question.service.QuestionCommandService;
+import com.miruni.backend.global.annotation.SwaggerBody;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -22,11 +24,25 @@ public class QuestionController implements QuestionApi {
 
     private final QuestionCommandService questionCommandService;
 
+    @SwaggerBody(content = @Content(
+            encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)))
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public QuestionResponseDto save(
-            @Valid @RequestPart("request") SaveQuestionRequestDto saveQuestionRequestDto,
-            @RequestPart(value = "question_images", required = false)List<MultipartFile> questionImages) {
+    public QuestionCommandResponseDto save(
+            @Valid @RequestPart("request") SaveQuestionRequestDto request,
+            @RequestPart(value = "questionImages", required = false)List<MultipartFile> questionImages) {
 
-        return questionCommandService.save(SaveQuestionCommandDto.of(saveQuestionRequestDto, questionImages));
+        return questionCommandService.save(SaveQuestionCommandDto.of(request, questionImages));
+    }
+
+    @SwaggerBody(content = @Content(
+            encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)
+    ))
+    @PatchMapping(value = {"/{questionId}"}, consumes =  MediaType.MULTIPART_FORM_DATA_VALUE)
+    public QuestionCommandResponseDto update(
+            @Valid @RequestPart("request") UpdateQuestionRequestDto request,
+            @RequestPart(value = "questionImages", required = false)List<MultipartFile> questionImages,
+            @PathVariable Long questionId
+    ){
+        return questionCommandService.update(UpdateQuestionCommandDto.of(request, questionImages, questionId));
     }
 }

--- a/src/main/java/com/miruni/backend/domain/question/dto/command/SaveQuestionCommandDto.java
+++ b/src/main/java/com/miruni/backend/domain/question/dto/command/SaveQuestionCommandDto.java
@@ -1,0 +1,22 @@
+package com.miruni.backend.domain.question.dto.command;
+
+import com.miruni.backend.domain.question.dto.request.SaveQuestionRequestDto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record SaveQuestionCommandDto(
+
+        String title,
+
+        String content,
+
+        boolean privacyAgreed,
+
+        List<MultipartFile> imageUrls
+) {
+
+    public static SaveQuestionCommandDto of(SaveQuestionRequestDto request, List<MultipartFile> imageUrls) {
+        return new SaveQuestionCommandDto(request.title(), request.content(), request.privacyAgreed(), imageUrls);
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/question/dto/command/UpdateQuestionCommandDto.java
+++ b/src/main/java/com/miruni/backend/domain/question/dto/command/UpdateQuestionCommandDto.java
@@ -1,0 +1,30 @@
+package com.miruni.backend.domain.question.dto.command;
+
+import com.miruni.backend.domain.question.dto.request.UpdateQuestionRequestDto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record UpdateQuestionCommandDto(
+        Long questionId,
+
+        String title,
+
+        String content,
+
+        List<Long> deleteImageIds,
+
+        List<MultipartFile> imageUrls
+
+) {
+    public static UpdateQuestionCommandDto of(UpdateQuestionRequestDto request,
+                                              List<MultipartFile> imageUrls,
+                                              Long questionId) {
+        return new UpdateQuestionCommandDto(
+                questionId,
+                request.title(),
+                request.content(),
+                request.deleteImageIds(),
+                imageUrls);
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/question/dto/request/SaveQuestionRequestDto.java
+++ b/src/main/java/com/miruni/backend/domain/question/dto/request/SaveQuestionRequestDto.java
@@ -1,0 +1,21 @@
+package com.miruni.backend.domain.question.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SaveQuestionRequestDto(
+
+        @NotBlank
+        @Schema(example = "앱 사용중 꺼짐")
+        String title,
+
+        @NotBlank
+        @Schema(example = "알람 아이콘을 누를 시에 자꾸 꺼집니다")
+        String content,
+
+        @NotNull
+        @Schema(example = "true")
+        boolean privacyAgreed
+) {
+}

--- a/src/main/java/com/miruni/backend/domain/question/dto/request/UpdateQuestionRequestDto.java
+++ b/src/main/java/com/miruni/backend/domain/question/dto/request/UpdateQuestionRequestDto.java
@@ -1,0 +1,20 @@
+package com.miruni.backend.domain.question.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record UpdateQuestionRequestDto(
+        @NotBlank
+        @Schema(example = "앱 사용중 꺼짐")
+        String title,
+
+        @NotBlank
+        @Schema(example = "알람 아이콘을 누를 시에 자꾸 꺼집니다")
+        String content,
+
+        List<Long> deleteImageIds
+) {
+}

--- a/src/main/java/com/miruni/backend/domain/question/dto/request/UpdateQuestionRequestDto.java
+++ b/src/main/java/com/miruni/backend/domain/question/dto/request/UpdateQuestionRequestDto.java
@@ -2,7 +2,6 @@ package com.miruni.backend.domain.question.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 

--- a/src/main/java/com/miruni/backend/domain/question/dto/response/GetListQuestionResponseDto.java
+++ b/src/main/java/com/miruni/backend/domain/question/dto/response/GetListQuestionResponseDto.java
@@ -1,0 +1,11 @@
+package com.miruni.backend.domain.question.dto.response;
+
+import java.util.List;
+
+public record GetListQuestionResponseDto(
+        List<QuestionQueryResponseDto> questionList
+) {
+    public static GetListQuestionResponseDto of(List<QuestionQueryResponseDto> questionQueryResponseDto) {
+        return new GetListQuestionResponseDto(questionQueryResponseDto);
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/question/dto/response/GetQuestionResponseDto.java
+++ b/src/main/java/com/miruni/backend/domain/question/dto/response/GetQuestionResponseDto.java
@@ -6,7 +6,7 @@ import com.miruni.backend.domain.question.entity.QuestionImage;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record QuestionResponseDto(
+public record GetQuestionResponseDto(
         Long id,
 
         String title,
@@ -17,11 +17,9 @@ public record QuestionResponseDto(
 
         List<Long> imageIds,
 
-        String email,
-
         LocalDateTime createdAt
 ) {
-    public static QuestionResponseDto from(Question question) {
+    public static GetQuestionResponseDto from(Question question) {
 
         List<String> imageUrls = question.getImages().stream()
                 .map(QuestionImage::getImageUrl)
@@ -31,13 +29,12 @@ public record QuestionResponseDto(
                 .map(QuestionImage::getId)
                 .toList();
 
-        return new QuestionResponseDto(
+        return new GetQuestionResponseDto(
                 question.getId(),
                 question.getTitle(),
                 question.getContent(),
                 imageUrls,
                 imageIds,
-                question.getUser().getEmail(),
                 question.getCreatedAt());
     }
 }

--- a/src/main/java/com/miruni/backend/domain/question/dto/response/QuestionCommandResponseDto.java
+++ b/src/main/java/com/miruni/backend/domain/question/dto/response/QuestionCommandResponseDto.java
@@ -1,0 +1,21 @@
+package com.miruni.backend.domain.question.dto.response;
+
+import com.miruni.backend.domain.question.entity.Question;
+
+import java.time.LocalDateTime;
+
+public record QuestionCommandResponseDto(
+        Long id,
+
+        String title,
+
+        LocalDateTime createdAt
+
+) {
+    public static QuestionCommandResponseDto from(Question question) {
+        return new QuestionCommandResponseDto(
+                question.getId(),
+                question.getTitle(),
+                question.getCreatedAt());
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/question/dto/response/QuestionQueryResponseDto.java
+++ b/src/main/java/com/miruni/backend/domain/question/dto/response/QuestionQueryResponseDto.java
@@ -1,0 +1,25 @@
+package com.miruni.backend.domain.question.dto.response;
+
+import com.miruni.backend.domain.question.entity.Question;
+
+import java.time.LocalDateTime;
+
+public record QuestionQueryResponseDto(
+        Long id,
+
+        String title,
+
+        LocalDateTime createdAt,
+
+        boolean isAnswer
+) {
+    public static QuestionQueryResponseDto from(Question question) {
+
+        return new QuestionQueryResponseDto(
+                question.getId(),
+                question.getTitle(),
+                question.getCreatedAt(),
+                question.isAnswered()
+        );
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/question/dto/response/QuestionResponseDto.java
+++ b/src/main/java/com/miruni/backend/domain/question/dto/response/QuestionResponseDto.java
@@ -3,14 +3,23 @@ package com.miruni.backend.domain.question.dto.response;
 import com.miruni.backend.domain.question.entity.Question;
 import com.miruni.backend.domain.question.entity.QuestionImage;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record QuestionResponseDto(
+        Long id,
+
         String title,
 
         String content,
 
-        List<String> imageUrl
+        List<String> imageUrl,
+
+        List<Long> imageIds,
+
+        String email,
+
+        LocalDateTime createdAt
 ) {
     public static QuestionResponseDto from(Question question) {
 
@@ -18,6 +27,17 @@ public record QuestionResponseDto(
                 .map(QuestionImage::getImageUrl)
                 .toList();
 
-        return new QuestionResponseDto(question.getTitle(), question.getContent(), imageUrls);
+        List<Long> imageIds = question.getImages().stream()
+                .map(QuestionImage::getId)
+                .toList();
+
+        return new QuestionResponseDto(
+                question.getId(),
+                question.getTitle(),
+                question.getContent(),
+                imageUrls,
+                imageIds,
+                question.getUser().getEmail(),
+                question.getCreatedAt());
     }
 }

--- a/src/main/java/com/miruni/backend/domain/question/dto/response/QuestionResponseDto.java
+++ b/src/main/java/com/miruni/backend/domain/question/dto/response/QuestionResponseDto.java
@@ -1,0 +1,23 @@
+package com.miruni.backend.domain.question.dto.response;
+
+import com.miruni.backend.domain.question.entity.Question;
+import com.miruni.backend.domain.question.entity.QuestionImage;
+
+import java.util.List;
+
+public record QuestionResponseDto(
+        String title,
+
+        String content,
+
+        List<String> imageUrl
+) {
+    public static QuestionResponseDto from(Question question) {
+
+        List<String> imageUrls = question.getImages().stream()
+                .map(QuestionImage::getImageUrl)
+                .toList();
+
+        return new QuestionResponseDto(question.getTitle(), question.getContent(), imageUrls);
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/question/entity/Question.java
+++ b/src/main/java/com/miruni/backend/domain/question/entity/Question.java
@@ -15,6 +15,8 @@ import java.util.List;
 @Table(name = "question")
 public class Question extends BaseEntity {
 
+    private static final int MAX_IMAGE_COUNT = 5;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "question_id")
@@ -64,6 +66,19 @@ public class Question extends BaseEntity {
                 .privacyAgreed(true)
                 .user(user)
                 .build();
+    }
+
+    public static void validateImageCount(int count){
+        if(count > MAX_IMAGE_COUNT){
+            throw BaseException.type(QuestionErrorCode.EXCEED_MAX_IMAGE_COUNT);
+        }
+    }
+
+    public void addImage(QuestionImage image){
+        if (this.images.size() >= MAX_IMAGE_COUNT) {
+            throw BaseException.type(QuestionErrorCode.EXCEED_MAX_IMAGE_COUNT);
+        }
+        this.images.add(image);
     }
 
     private static void validateAgreed(boolean privacyAgreed) {

--- a/src/main/java/com/miruni/backend/domain/question/entity/Question.java
+++ b/src/main/java/com/miruni/backend/domain/question/entity/Question.java
@@ -12,8 +12,6 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "question")
 public class Question extends BaseEntity {
 
@@ -41,16 +39,30 @@ public class Question extends BaseEntity {
     @OneToOne(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
     private Answer answer;
 
+    @Builder
+    private Question(final String title,
+                     final String content,
+                     final boolean privacyAgreed,
+                     final User user){
+        this.title = title;
+        this.content = content;
+        this.privacyAgreed = privacyAgreed;
+        this.user = user;
+        this.images = new ArrayList<>();
+    }
+
     public static Question create(final String title,
                                   final String content,
-                                  final boolean privacyAgreed) {
+                                  final boolean privacyAgreed,
+                                  final User user) {
 
         validateAgreed(privacyAgreed);
 
         return Question.builder()
                 .title(title)
                 .content(content)
-                .privacyAgreed(privacyAgreed)
+                .privacyAgreed(true)
+                .user(user)
                 .build();
     }
 

--- a/src/main/java/com/miruni/backend/domain/question/entity/Question.java
+++ b/src/main/java/com/miruni/backend/domain/question/entity/Question.java
@@ -68,22 +68,30 @@ public class Question extends BaseEntity {
                 .build();
     }
 
-    public static void validateImageCount(int count){
-        if(count > MAX_IMAGE_COUNT){
-            throw BaseException.type(QuestionErrorCode.EXCEED_MAX_IMAGE_COUNT);
-        }
+    public void update(final String title,
+                               final String content){
+        this.title = title;
+        this.content = content;
     }
 
+
     public void addImage(QuestionImage image){
-        if (this.images.size() >= MAX_IMAGE_COUNT) {
-            throw BaseException.type(QuestionErrorCode.EXCEED_MAX_IMAGE_COUNT);
-        }
         this.images.add(image);
+    }
+
+    public void removeImage(QuestionImage image){
+        this.images.remove(image);
     }
 
     private static void validateAgreed(boolean privacyAgreed) {
         if(!privacyAgreed) {
             throw BaseException.type(QuestionErrorCode.AGREEMENT_NOT_ACCEPT);
+        }
+    }
+
+    public static void validateImageCount(int count){
+        if(count > MAX_IMAGE_COUNT){
+            throw BaseException.type(QuestionErrorCode.EXCEED_MAX_IMAGE_COUNT);
         }
     }
 

--- a/src/main/java/com/miruni/backend/domain/question/entity/Question.java
+++ b/src/main/java/com/miruni/backend/domain/question/entity/Question.java
@@ -1,7 +1,9 @@
 package com.miruni.backend.domain.question.entity;
 
+import com.miruni.backend.domain.question.exception.QuestionErrorCode;
 import com.miruni.backend.domain.user.entity.User;
 import com.miruni.backend.global.common.BaseEntity;
+import com.miruni.backend.global.exception.BaseException;
 import jakarta.persistence.*;
 import lombok.*;
 import java.util.ArrayList;
@@ -38,5 +40,24 @@ public class Question extends BaseEntity {
 
     @OneToOne(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
     private Answer answer;
+
+    public static Question create(final String title,
+                                  final String content,
+                                  final boolean privacyAgreed) {
+
+        validateAgreed(privacyAgreed);
+
+        return Question.builder()
+                .title(title)
+                .content(content)
+                .privacyAgreed(privacyAgreed)
+                .build();
+    }
+
+    private static void validateAgreed(boolean privacyAgreed) {
+        if(!privacyAgreed) {
+            throw BaseException.type(QuestionErrorCode.AGREEMENT_NOT_ACCEPT);
+        }
+    }
 
 }

--- a/src/main/java/com/miruni/backend/domain/question/entity/Question.java
+++ b/src/main/java/com/miruni/backend/domain/question/entity/Question.java
@@ -74,13 +74,21 @@ public class Question extends BaseEntity {
         this.content = content;
     }
 
-
     public void addImage(QuestionImage image){
         this.images.add(image);
     }
 
-    public void removeImage(QuestionImage image){
-        this.images.remove(image);
+    public void removeImage(QuestionImage image) {
+        images.remove(image);
+        image.disconnect();
+    }
+
+    public void removeAll(List<QuestionImage> images){
+        images.forEach(this::removeImage);
+    }
+
+    public boolean isAnswered() {
+        return this.answer != null;
     }
 
     private static void validateAgreed(boolean privacyAgreed) {

--- a/src/main/java/com/miruni/backend/domain/question/entity/QuestionImage.java
+++ b/src/main/java/com/miruni/backend/domain/question/entity/QuestionImage.java
@@ -31,4 +31,8 @@ public class QuestionImage extends BaseEntity {
                 .imageUrl(imageUrl)
                 .build();
     }
+
+    public void disconnect(){
+        this.question = null;
+    }
 }

--- a/src/main/java/com/miruni/backend/domain/question/entity/QuestionImage.java
+++ b/src/main/java/com/miruni/backend/domain/question/entity/QuestionImage.java
@@ -24,4 +24,11 @@ public class QuestionImage extends BaseEntity {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
+    public static QuestionImage create(final Question question,
+                                       final String imageUrl){
+        return QuestionImage.builder()
+                .question(question)
+                .imageUrl(imageUrl)
+                .build();
+    }
 }

--- a/src/main/java/com/miruni/backend/domain/question/exception/QuestionErrorCode.java
+++ b/src/main/java/com/miruni/backend/domain/question/exception/QuestionErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum QuestionErrorCode implements ErrorCode {
 
     AGREEMENT_NOT_ACCEPT(HttpStatus.BAD_REQUEST, "QUESTION_001", "프라이버시 동의가 이루어지지 않았습니다."),
-    FAILED_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR,"QUESTION_002", "")
+    FAILED_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR,"QUESTION_002", "이미지 업로드가 실패했습니다"),
+    EXCEED_MAX_IMAGE_COUNT(HttpStatus.BAD_REQUEST, "QUESTION_003", "이미지 개수는 5개를 초과할 수 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/miruni/backend/domain/question/exception/QuestionErrorCode.java
+++ b/src/main/java/com/miruni/backend/domain/question/exception/QuestionErrorCode.java
@@ -11,7 +11,9 @@ public enum QuestionErrorCode implements ErrorCode {
 
     AGREEMENT_NOT_ACCEPT(HttpStatus.BAD_REQUEST, "QUESTION_001", "프라이버시 동의가 이루어지지 않았습니다."),
     FAILED_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR,"QUESTION_002", "이미지 업로드가 실패했습니다"),
-    EXCEED_MAX_IMAGE_COUNT(HttpStatus.BAD_REQUEST, "QUESTION_003", "이미지 개수는 5개를 초과할 수 없습니다.")
+    EXCEED_MAX_IMAGE_COUNT(HttpStatus.BAD_REQUEST, "QUESTION_003", "이미지 개수는 5개를 초과할 수 없습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_004", "해당하는 id의 이미지를 찾을 수 없습니다."),
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_005", "해당하는 id의 질문을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/miruni/backend/domain/question/exception/QuestionErrorCode.java
+++ b/src/main/java/com/miruni/backend/domain/question/exception/QuestionErrorCode.java
@@ -1,0 +1,19 @@
+package com.miruni.backend.domain.question.exception;
+
+import com.miruni.backend.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum QuestionErrorCode implements ErrorCode {
+
+    AGREEMENT_NOT_ACCEPT(HttpStatus.BAD_REQUEST, "QUESTION_001", "프라이버시 동의가 이루어지지 않았습니다."),
+    FAILED_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR,"QUESTION_002", "")
+    ;
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/miruni/backend/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/miruni/backend/domain/question/repository/QuestionRepository.java
@@ -3,5 +3,8 @@ package com.miruni.backend.domain.question.repository;
 import com.miruni.backend.domain.question.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+    List<Question> findByUserId(Long userId);
 }

--- a/src/main/java/com/miruni/backend/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/miruni/backend/domain/question/repository/QuestionRepository.java
@@ -1,0 +1,7 @@
+package com.miruni.backend.domain.question.repository;
+
+import com.miruni.backend.domain.question.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/com/miruni/backend/domain/question/service/QuestionCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/question/service/QuestionCommandService.java
@@ -1,0 +1,51 @@
+package com.miruni.backend.domain.question.service;
+
+import com.miruni.backend.domain.question.dto.command.SaveQuestionCommandDto;
+import com.miruni.backend.domain.question.dto.response.QuestionResponseDto;
+import com.miruni.backend.domain.question.entity.Question;
+import com.miruni.backend.domain.question.exception.QuestionErrorCode;
+import com.miruni.backend.domain.question.repository.QuestionRepository;
+import com.miruni.backend.domain.user.entity.User;
+import com.miruni.backend.global.exception.BaseException;
+import com.miruni.backend.global.util.S3Util;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QuestionCommandService {
+
+    private final QuestionRepository questionRepository;
+    private final S3Util s3Util;
+
+    public QuestionResponseDto save(SaveQuestionCommandDto command) {
+
+        Question question = Question.create(command.title(), command.content(), command.privacyAgreed());
+
+        questionRepository.save(question);
+
+
+        return QuestionResponseDto.from(question);
+    }
+
+    private void uploadProfileImages(User user, List<MultipartFile> profileImages) {
+        if(profileImages != null && !profileImages.isEmpty()) {
+            for (MultipartFile profileImage : profileImages) {
+                String key;
+                try {
+                    key = s3Util.uploadFile(profileImage, "users/" + user.getId() + "/profiles");
+                } catch (BaseException e) {
+                    throw e;
+                } catch (RuntimeException e) {
+                    log.error("프로필 이미지 업로드 실패: userId = {}", user.getId(), e);
+                    throw BaseException.type(QuestionErrorCode.FAILED_UPLOAD_IMAGE);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/question/service/QuestionCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/question/service/QuestionCommandService.java
@@ -1,12 +1,14 @@
 package com.miruni.backend.domain.question.service;
 
 import com.miruni.backend.domain.question.dto.command.SaveQuestionCommandDto;
-import com.miruni.backend.domain.question.dto.response.QuestionResponseDto;
+import com.miruni.backend.domain.question.dto.command.UpdateQuestionCommandDto;
+import com.miruni.backend.domain.question.dto.response.QuestionCommandResponseDto;
 import com.miruni.backend.domain.question.entity.Question;
 import com.miruni.backend.domain.question.entity.QuestionImage;
 import com.miruni.backend.domain.question.exception.QuestionErrorCode;
 import com.miruni.backend.domain.question.repository.QuestionRepository;
 import com.miruni.backend.domain.user.entity.User;
+import com.miruni.backend.domain.user.repository.UserRepository;
 import com.miruni.backend.global.exception.BaseException;
 import com.miruni.backend.global.util.S3Util;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -25,18 +26,17 @@ public class QuestionCommandService {
 
     private final QuestionRepository questionRepository;
     private final S3Util s3Util;
+    private final UserRepository userRepository;
 
     @Transactional
-    public QuestionResponseDto save(SaveQuestionCommandDto command) {
-
-        LocalDate localDate = LocalDate.now();
-
-        User user = User.create("추상윤", "dhzkltdh@gmail.com", localDate,
-                "010-7689-3141", "tkddbs3535", "chuchu");
+    public QuestionCommandResponseDto save(SaveQuestionCommandDto command) {
 
         List<MultipartFile> images = command.imageUrls();
 
         Question.validateImageCount(images != null ? images.size() : 0);
+
+        User user = userRepository.findById(1L)
+                .orElseThrow(IllegalArgumentException::new);
 
         Question question = questionRepository.save(
                 Question.create(command.title(),
@@ -47,7 +47,30 @@ public class QuestionCommandService {
 
         uploadQuestionImages(question, images);
 
-        return QuestionResponseDto.from(question);
+        return QuestionCommandResponseDto.from(question);
+    }
+
+    @Transactional
+    public QuestionCommandResponseDto update(UpdateQuestionCommandDto command) {
+
+        //나중에 userId와 같이 검증하기 리팩토링
+        Question question = questionRepository.findById(command.questionId())
+                .orElseThrow(() -> BaseException.type(QuestionErrorCode.QUESTION_NOT_FOUND));
+
+        validateFinalImageCount(question, command);
+
+        if (command.deleteImageIds() != null) {
+            deleteImagesById(question, command.deleteImageIds());
+        }
+
+        if (command.imageUrls() != null) {
+            uploadQuestionImages(question, command.imageUrls());
+        }
+
+        question.update(command.title(), command.content());
+        return QuestionCommandResponseDto.from(question);
+
+
     }
 
     private void uploadQuestionImages(Question question, List<MultipartFile> images){
@@ -62,7 +85,6 @@ public class QuestionCommandService {
         }
     }
 
-
     private String uploadImageToS3(Question question, MultipartFile image) {
         try {
             String directory = String.format("questions/%d/images", question.getId());
@@ -70,8 +92,31 @@ public class QuestionCommandService {
         } catch (BaseException e) {
                     throw e;
         } catch (RuntimeException e) {
-            log.error("질문 이미지 업로드 실패: userId = {}", question.getId(), e);
+            log.error("질문 이미지 업로드 실패: questionId = {}", question.getId(), e);
             throw BaseException.type(QuestionErrorCode.FAILED_UPLOAD_IMAGE);
         }
+    }
+
+    private void validateFinalImageCount(Question question, UpdateQuestionCommandDto command) {
+        int current = question.getImages().size();
+        int delete = command.deleteImageIds() != null ? command.deleteImageIds().size() : 0;
+        int add = command.imageUrls() != null ? command.imageUrls().size() : 0;
+        Question.validateImageCount(current - delete + add);
+    }
+
+
+    private void deleteImagesById(Question question, List<Long> images) {
+        List<QuestionImage> imagesToDelete = question.getImages().stream()
+                .filter(img -> images.contains(img.getId()))
+                .toList();
+
+        if(imagesToDelete.size() != images.size()){
+            throw BaseException.type(QuestionErrorCode.IMAGE_NOT_FOUND);
+        }
+
+        imagesToDelete.forEach(image -> {
+            s3Util.deleteFile(image.getImageUrl());
+            question.removeImage(image);
+        });
     }
 }

--- a/src/main/java/com/miruni/backend/domain/question/service/QuestionCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/question/service/QuestionCommandService.java
@@ -3,6 +3,7 @@ package com.miruni.backend.domain.question.service;
 import com.miruni.backend.domain.question.dto.command.SaveQuestionCommandDto;
 import com.miruni.backend.domain.question.dto.response.QuestionResponseDto;
 import com.miruni.backend.domain.question.entity.Question;
+import com.miruni.backend.domain.question.entity.QuestionImage;
 import com.miruni.backend.domain.question.exception.QuestionErrorCode;
 import com.miruni.backend.domain.question.repository.QuestionRepository;
 import com.miruni.backend.domain.user.entity.User;
@@ -11,8 +12,10 @@ import com.miruni.backend.global.util.S3Util;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -23,29 +26,48 @@ public class QuestionCommandService {
     private final QuestionRepository questionRepository;
     private final S3Util s3Util;
 
+    @Transactional
     public QuestionResponseDto save(SaveQuestionCommandDto command) {
 
-        Question question = Question.create(command.title(), command.content(), command.privacyAgreed());
+        LocalDate localDate = LocalDate.now();
 
-        questionRepository.save(question);
+        User user = User.create("추상윤", "dhzkltdh@gmail.com", localDate,
+                "010-7689-3141", "tkddbs3535", "chuchu");
 
+        Question question = questionRepository.save(
+                Question.create(command.title(),
+                        command.content(),
+                        command.privacyAgreed(),
+                        user)
+        );
+
+        uploadQuestionImages(question, command.imageUrls());
 
         return QuestionResponseDto.from(question);
     }
 
-    private void uploadProfileImages(User user, List<MultipartFile> profileImages) {
-        if(profileImages != null && !profileImages.isEmpty()) {
-            for (MultipartFile profileImage : profileImages) {
-                String key;
-                try {
-                    key = s3Util.uploadFile(profileImage, "users/" + user.getId() + "/profiles");
-                } catch (BaseException e) {
+    private void uploadQuestionImages(Question question, List<MultipartFile> images){
+        if(images == null || images.isEmpty()){
+            return;
+        }
+
+        for(MultipartFile image : images){
+            String key = uploadImageToS3(question, image);
+            QuestionImage questionImage = QuestionImage.create(question, key);
+            question.getImages().add(questionImage);
+        }
+    }
+
+
+    private String uploadImageToS3(Question question, MultipartFile image) {
+        try {
+            String directory = String.format("questions/%d/images", question.getId());
+            return s3Util.uploadFile(image, directory);
+        } catch (BaseException e) {
                     throw e;
-                } catch (RuntimeException e) {
-                    log.error("프로필 이미지 업로드 실패: userId = {}", user.getId(), e);
-                    throw BaseException.type(QuestionErrorCode.FAILED_UPLOAD_IMAGE);
-                }
-            }
+        } catch (RuntimeException e) {
+            log.error("질문 이미지 업로드 실패: userId = {}", question.getId(), e);
+            throw BaseException.type(QuestionErrorCode.FAILED_UPLOAD_IMAGE);
         }
     }
 }

--- a/src/main/java/com/miruni/backend/domain/question/service/QuestionCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/question/service/QuestionCommandService.java
@@ -116,7 +116,8 @@ public class QuestionCommandService {
 
         imagesToDelete.forEach(image -> {
             s3Util.deleteFile(image.getImageUrl());
-            question.removeImage(image);
         });
+        question.removeAll(imagesToDelete);
+        questionRepository.flush();
     }
 }

--- a/src/main/java/com/miruni/backend/domain/question/service/QuestionCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/question/service/QuestionCommandService.java
@@ -34,6 +34,10 @@ public class QuestionCommandService {
         User user = User.create("추상윤", "dhzkltdh@gmail.com", localDate,
                 "010-7689-3141", "tkddbs3535", "chuchu");
 
+        List<MultipartFile> images = command.imageUrls();
+
+        Question.validateImageCount(images != null ? images.size() : 0);
+
         Question question = questionRepository.save(
                 Question.create(command.title(),
                         command.content(),
@@ -41,7 +45,7 @@ public class QuestionCommandService {
                         user)
         );
 
-        uploadQuestionImages(question, command.imageUrls());
+        uploadQuestionImages(question, images);
 
         return QuestionResponseDto.from(question);
     }
@@ -54,7 +58,7 @@ public class QuestionCommandService {
         for(MultipartFile image : images){
             String key = uploadImageToS3(question, image);
             QuestionImage questionImage = QuestionImage.create(question, key);
-            question.getImages().add(questionImage);
+            question.addImage(questionImage);
         }
     }
 

--- a/src/main/java/com/miruni/backend/domain/question/service/QuestionQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/question/service/QuestionQueryService.java
@@ -1,0 +1,38 @@
+package com.miruni.backend.domain.question.service;
+
+import com.miruni.backend.domain.question.dto.response.GetListQuestionResponseDto;
+import com.miruni.backend.domain.question.dto.response.GetQuestionResponseDto;
+import com.miruni.backend.domain.question.dto.response.QuestionQueryResponseDto;
+import com.miruni.backend.domain.question.entity.Question;
+import com.miruni.backend.domain.question.exception.QuestionErrorCode;
+import com.miruni.backend.domain.question.repository.QuestionRepository;
+import com.miruni.backend.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionQueryService {
+    private final QuestionRepository questionRepository;
+
+    @Transactional(readOnly = true)
+    public GetQuestionResponseDto getQuestion(Long questionId){
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> BaseException.type(QuestionErrorCode.QUESTION_NOT_FOUND));
+
+        return GetQuestionResponseDto.from(question);
+    }
+
+    @Transactional(readOnly = true)
+    public GetListQuestionResponseDto getListQuestion(){
+        List<Question> questions = questionRepository.findByUserId(1L);
+
+        return GetListQuestionResponseDto.of(
+                questions.stream().map(QuestionQueryResponseDto::from)
+                        .toList());
+    }
+}
+

--- a/src/main/java/com/miruni/backend/domain/user/entity/User.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/User.java
@@ -72,7 +72,7 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FcmToken> fcmTokens = new ArrayList<>();
 
-    public User create(String name, String email, LocalDate birth,
+    public static User create(String name, String email, LocalDate birth,
                        String phoneNumber, String password, String nickname){
         return User.builder()
                 .name(name)

--- a/src/main/java/com/miruni/backend/domain/user/entity/User.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/User.java
@@ -72,4 +72,15 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FcmToken> fcmTokens = new ArrayList<>();
 
+    public User create(String name, String email, LocalDate birth,
+                       String phoneNumber, String password, String nickname){
+        return User.builder()
+                .name(name)
+                .email(email)
+                .birth(birth)
+                .phoneNumber(phoneNumber)
+                .password(password)
+                .nickname(nickname)
+                .build();
+    }
 }

--- a/src/main/java/com/miruni/backend/domain/user/entity/User.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/User.java
@@ -72,15 +72,4 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FcmToken> fcmTokens = new ArrayList<>();
 
-    public static User create(String name, String email, LocalDate birth,
-                       String phoneNumber, String password, String nickname){
-        return User.builder()
-                .name(name)
-                .email(email)
-                .birth(birth)
-                .phoneNumber(phoneNumber)
-                .password(password)
-                .nickname(nickname)
-                .build();
-    }
 }

--- a/src/main/java/com/miruni/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/miruni/backend/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.miruni.backend.domain.user.repository;
+
+import com.miruni.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/miruni/backend/global/annotation/SwaggerBody.java
+++ b/src/main/java/com/miruni/backend/global/annotation/SwaggerBody.java
@@ -1,0 +1,34 @@
+package com.miruni.backend.global.annotation;
+
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@RequestBody
+@Inherited
+public @interface SwaggerBody {
+
+    @AliasFor(annotation = RequestBody.class)
+    String description() default "";
+
+    @AliasFor(annotation = RequestBody.class)
+    Content[] content() default {};
+
+    @AliasFor(annotation = RequestBody.class)
+    boolean required() default false;
+
+    @AliasFor(annotation = RequestBody.class)
+    Extension[] extensions() default {};
+
+    @AliasFor(annotation = RequestBody.class)
+    String ref() default "";
+
+    @AliasFor(annotation = RequestBody.class)
+    boolean useParameterTypeSchema() default false;
+
+}

--- a/src/main/java/com/miruni/backend/global/exception/CommonErrorCode.java
+++ b/src/main/java/com/miruni/backend/global/exception/CommonErrorCode.java
@@ -17,11 +17,25 @@ public enum CommonErrorCode implements ErrorCode {
     NOT_SUPPORTED_METHOD_ERROR(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_006", "지원하지 않는 HTTP 메서드입니다."),
     NOT_SUPPORTED_URI_ERROR(HttpStatus.NOT_FOUND, "COMMON_007", "지원하지 않는 URI입니다."),
     NOT_SUPPORTED_MEDIA_TYPE_ERROR(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "COMMON_008", "지원하지 않는 미디어 타입입니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON_009", "유효하지 않은 값입니다."),
 
     // ===== 서버 에러 (5xx) =====
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_001", "서버 내부 오류가 발생했습니다."),
     DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_002", "데이터베이스 오류가 발생했습니다."),
-    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "SERVER_003", "외부 API 호출에 실패했습니다.");
+    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "SERVER_003", "외부 API 호출에 실패했습니다."),
+
+    // == 이미지 파일 에러  == //
+    FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, "FILE_001", "파일이 비어있습니다."),
+    NOT_SUPPORTED_TYPE_ERROR(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "FILE_002", "지원하지 않는 형식의 타입입니다."),
+    NOT_FOUND_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "FILE_003", "파일 확장자가 없습니다."),
+    FILE_SIZE_EXCEED_LIMIT(HttpStatus.BAD_REQUEST, "FILE_004", "파일크기가 최대 제한을 초과했습니다."),
+    NOT_IMAGE_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "FILE_005", "이미지 파일만 업로드 가능합니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_006", "파일 업로드에 실패했습니다."),
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_007", "파일 삭제에 실패했습니다."),
+    INVALID_FILE_EXTENSION(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "FILE_008", "지원하지 않는 미디어타입입니다."),
+    GENERATED_PRESIGNED_URL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_009", "presigned URL을 생성하는 데 실패했습니다.")
+    ;
+
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/com/miruni/backend/global/util/S3Util.java
+++ b/src/main/java/com/miruni/backend/global/util/S3Util.java
@@ -1,0 +1,147 @@
+package com.miruni.backend.global.util;
+
+import com.miruni.backend.global.exception.BaseException;
+import com.miruni.backend.global.exception.CommonErrorCode;
+import com.miruni.backend.global.properties.S3Properties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Util {
+
+    private final S3Presigner s3Presigner;
+    private final S3Properties s3Properties;
+    private final S3Client s3Client;
+
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png", "gif", "webp");
+
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+
+    public String uploadFile(MultipartFile file, String directory){
+        if(directory == null || directory.contains("..")){
+            throw BaseException.type(CommonErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        String extension = getExtension(file.getOriginalFilename());
+        String contentType = file.getContentType();
+        validateFile(file, extension, contentType);
+
+        String fileName = UUID.randomUUID() + extension;
+        String key = directory + "/" + fileName;
+
+        try{
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(s3Properties.bucket())
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .build();
+
+            s3Client.putObject(
+                    putObjectRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize())
+            );
+            log.info("File uploaded successfully: {}", key);
+            return key;
+        } catch(IOException | S3Exception e){
+            log.error("File upload failed: {}", key, e);
+            throw BaseException.type(CommonErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    public String generatePresignedUrl(String key, int durationMinutes){
+        try{
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(s3Properties.bucket())
+                    .key(key)
+                    .build();
+
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(durationMinutes))
+                    .getObjectRequest(getObjectRequest)
+                    .build();
+
+            PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+
+            return presignedRequest.url().toString();
+
+        }catch (S3Exception e){
+            log.error("PresignedGetObjectRequest failed: {}", key, e);
+            throw BaseException.type(CommonErrorCode.GENERATED_PRESIGNED_URL_FAILED);
+        }
+    }
+
+    public void deleteFile(String key){
+        try{
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(s3Properties.bucket())
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("File deleted successfully: {}", key);
+        } catch(S3Exception e){
+            log.error("DeleteObject failed: {}", key, e);
+            throw BaseException.type(CommonErrorCode.FILE_DELETE_FAILED);
+        }
+    }
+
+    public String getPublicUrl(String key){
+        if (key == null) return null;
+        return s3Properties.bucket() + "/" + key;
+    }
+
+    private void validateFile(MultipartFile file, String extension, String contentType){
+        if(file == null || file.isEmpty()){
+            throw BaseException.type(CommonErrorCode.FILE_IS_EMPTY);
+        }
+
+        if(file.getSize() > MAX_FILE_SIZE){
+            throw BaseException.type(CommonErrorCode.FILE_SIZE_EXCEED_LIMIT);
+        }
+
+        if(extension.isEmpty()){
+            throw BaseException.type(CommonErrorCode.NOT_FOUND_FILE_EXTENSION);
+        }
+
+        if(extension.length() <= 1){
+            throw BaseException.type(CommonErrorCode.INVALID_FILE_EXTENSION);
+        }
+
+        String ext = extension.substring(1);
+        if(!ALLOWED_EXTENSIONS.contains(ext)){
+            throw BaseException.type(CommonErrorCode.INVALID_FILE_EXTENSION);
+        }
+
+        if(contentType != null && !contentType.startsWith("image/")){
+            throw BaseException.type(CommonErrorCode.NOT_IMAGE_CONTENT_TYPE);
+        }
+    }
+
+    private String getExtension(String filename){
+        if (filename == null || !filename.contains(".")){
+            return "";
+        }
+        return filename.substring(filename.lastIndexOf(".")).toLowerCase();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,13 @@ spring:
     hibernate:
       ddl-auto: create
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 50MB
+
+
+
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,8 +20,6 @@ spring:
       max-file-size: 10MB
       max-request-size: 50MB
 
-
-
 management:
   endpoints:
     web:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #9 
- close : #9 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
- 고객센터 문의 생성 및 업데이트
- 리스트 조회및 상세 조회

## 📸 스크린샷 (선택)

## 📢 참고 사항
Swagger Request Part 때문에 어노테이션 추가했습니다 
업로드된 사진 삭제시에
SQL에서 delete가 늦게 되는 바람에 꼬여서 무한 로딩이 되는 부분 .flush()를 넣어서 해결했습니다
presigned URL 보다 사진 5장 이하로 올리는 것으로 알고 있어서 Server에서 직접업로드하는 방식으로 구현했습니다