### PR TITLE
[feat] 캘린더 페이지의 일정 조회 API 구현

### DIFF
--- a/src/main/java/com/miruni/backend/domain/plan/controller/PlanApi.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/PlanApi.java
@@ -1,0 +1,55 @@
+package com.miruni.backend.domain.plan.controller;
+
+import com.miruni.backend.domain.plan.dto.response.DailyPlanResponse;
+import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
+import com.miruni.backend.domain.plan.dto.response.PlanDetailResponse;
+import com.miruni.backend.domain.plan.type.PlanType;
+import com.miruni.backend.global.authroize.LoginUser;
+import com.miruni.backend.global.exception.CustomErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name="plan", description = "일정 분할/조회/관리 API")
+public interface PlanApi {
+
+    @Operation(
+            summary = "캘린더 조회",
+            description = "특정 년/월의 날짜별 미완료 일정 개수를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "캘린더 조회 성공")
+    })
+    List<MonthlyPlanResponse> getMonthlyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month);
+
+    @Operation(
+            summary = "특정 날짜의 완료/미완료 일정 조회",
+            description = "특정 날짜의 완료/미완료 일정을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일정 조회 성공")
+    })
+    DailyPlanResponse getDailyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month, @RequestParam int day);
+
+    @Operation(
+            summary = "특정 일정 조회",
+            description = "특정 일정을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일정 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "해당 일정에 권한 없음",
+                    content = @Content(schema = @Schema(implementation = CustomErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 일정",
+                    content = @Content(schema = @Schema(implementation = CustomErrorResponse.class))
+            )
+    })
+    PlanDetailResponse getPlanDetail(@LoginUser Long userId, @PathVariable Long planId, @RequestParam PlanType planType);
+}

--- a/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
@@ -1,0 +1,25 @@
+package com.miruni.backend.domain.plan.controller;
+
+import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
+import com.miruni.backend.domain.plan.service.PlanQueryService;
+import com.miruni.backend.global.authroize.LoginUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/plans")
+@RequiredArgsConstructor
+public class PlanController {
+
+    private final PlanQueryService planQueryService;
+
+    @GetMapping("/monthly")
+    public List<MonthlyPlanResponse> getMonthlyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month) {
+        return planQueryService.getMonthlyPlan(userId, year, month);
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
@@ -2,13 +2,11 @@ package com.miruni.backend.domain.plan.controller;
 
 import com.miruni.backend.domain.plan.dto.response.DailyPlanResponse;
 import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
+import com.miruni.backend.domain.plan.dto.response.PlanDetailResponse;
 import com.miruni.backend.domain.plan.service.PlanQueryService;
 import com.miruni.backend.global.authroize.LoginUser;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -27,5 +25,10 @@ public class PlanController {
     @GetMapping("/daily")
     public DailyPlanResponse getDailyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month, @RequestParam int day) {
         return planQueryService.getDailyPlan(userId, year, month, day);
+    }
+
+    @GetMapping("/{planId}")
+    public PlanDetailResponse getPlanDetail(@LoginUser Long userId, @PathVariable Long planId, @RequestParam String planType) {
+        return planQueryService.getPlanDetail(userId, planId, planType);
     }
 }

--- a/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
@@ -14,7 +14,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/plans")
 @RequiredArgsConstructor
-public class PlanController {
+public class PlanController implements PlanApi{
 
     private final PlanQueryService planQueryService;
 

--- a/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
@@ -1,5 +1,6 @@
 package com.miruni.backend.domain.plan.controller;
 
+import com.miruni.backend.domain.plan.dto.response.DailyPlanResponse;
 import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
 import com.miruni.backend.domain.plan.service.PlanQueryService;
 import com.miruni.backend.global.authroize.LoginUser;
@@ -21,5 +22,10 @@ public class PlanController {
     @GetMapping("/monthly")
     public List<MonthlyPlanResponse> getMonthlyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month) {
         return planQueryService.getMonthlyPlan(userId, year, month);
+    }
+
+    @GetMapping("/daily")
+    public DailyPlanResponse getDailyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month, @RequestParam int day) {
+        return planQueryService.getDailyPlan(userId, year, month, day);
     }
 }

--- a/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
@@ -4,6 +4,7 @@ import com.miruni.backend.domain.plan.dto.response.DailyPlanResponse;
 import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
 import com.miruni.backend.domain.plan.dto.response.PlanDetailResponse;
 import com.miruni.backend.domain.plan.service.PlanQueryService;
+import com.miruni.backend.domain.plan.type.PlanType;
 import com.miruni.backend.global.authroize.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -28,7 +29,7 @@ public class PlanController {
     }
 
     @GetMapping("/{planId}")
-    public PlanDetailResponse getPlanDetail(@LoginUser Long userId, @PathVariable Long planId, @RequestParam String planType) {
+    public PlanDetailResponse getPlanDetail(@LoginUser Long userId, @PathVariable Long planId, @RequestParam PlanType planType) {
         return planQueryService.getPlanDetail(userId, planId, planType);
     }
 }

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
@@ -1,0 +1,49 @@
+package com.miruni.backend.domain.plan.dto.response;
+
+import com.miruni.backend.domain.plan.entity.AiPlan;
+import com.miruni.backend.domain.plan.entity.BasicPlan;
+import com.miruni.backend.domain.plan.entity.Priority;
+
+import java.time.LocalTime;
+import java.util.List;
+
+public record DailyPlanResponse(
+        List<DailyPlanItemResponse> unfinishedPlan,
+        List<DailyPlanItemResponse> finishedPlan
+) {
+
+    public record DailyPlanItemResponse(
+            String planType,
+            Long planId,
+            String title,
+            String subTitle,
+            LocalTime scheduledTime,
+            Priority priority,
+            boolean isDone
+    ) {
+
+        public static DailyPlanItemResponse fromBasic(BasicPlan plan) {
+            return new DailyPlanItemResponse(
+                    "BASIC",
+                    plan.getId(),
+                    plan.getTitle(),
+                    null,
+                    plan.getScheduledTime(),
+                    plan.getPriority(),
+                    plan.isDone()
+            );
+        }
+
+        public static DailyPlanItemResponse fromAi(AiPlan aiPlan) {
+            return new DailyPlanItemResponse(
+                    "AI",
+                    aiPlan.getId(),
+                    aiPlan.getPlan().getTitle(), // TODO
+                    aiPlan.getSubTitle(),
+                    aiPlan.getScheduledTime(),
+                    aiPlan.getPlan().getPriority(),
+                    aiPlan.isDone()
+            );
+        }
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
@@ -11,6 +11,13 @@ public record DailyPlanResponse(
         List<DailyPlanItemResponse> unfinishedPlan,
         List<DailyPlanItemResponse> finishedPlan
 ) {
+    public static DailyPlanResponse of(List<DailyPlanItemResponse> unfinishedPlan, List<DailyPlanItemResponse> finishedPlan
+    ) {
+        return new DailyPlanResponse(
+                unfinishedPlan,
+                finishedPlan
+        );
+    }
 
     public record DailyPlanItemResponse(
             String planType,
@@ -21,7 +28,6 @@ public record DailyPlanResponse(
             Priority priority,
             boolean isDone
     ) {
-
         public static DailyPlanItemResponse fromBasic(BasicPlan plan) {
             return new DailyPlanItemResponse(
                     "BASIC",

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
@@ -5,8 +5,9 @@ import com.miruni.backend.domain.plan.entity.BasicPlan;
 import com.miruni.backend.domain.plan.entity.Priority;
 import com.miruni.backend.domain.plan.type.PlanType;
 
-import java.time.LocalTime;
 import java.util.List;
+
+import static com.miruni.backend.global.common.DateTimeFormatUtil.formatTime;
 
 public record DailyPlanResponse(
         List<DailyPlanItemResponse> unfinishedPlan,
@@ -25,7 +26,7 @@ public record DailyPlanResponse(
             Long planId,
             String title,
             String subTitle,
-            LocalTime scheduledTime,
+            String scheduledTime,
             Priority priority,
             boolean isDone
     ) {
@@ -35,7 +36,7 @@ public record DailyPlanResponse(
                     plan.getId(),
                     plan.getTitle(),
                     null,
-                    plan.getScheduledTime(),
+                    formatTime(plan.getScheduledTime()),
                     plan.getPriority(),
                     plan.isDone()
             );
@@ -47,7 +48,7 @@ public record DailyPlanResponse(
                     aiPlan.getId(),
                     aiPlan.getPlan().getTitle(), // TODO
                     aiPlan.getSubTitle(),
-                    aiPlan.getScheduledTime(),
+                    formatTime(aiPlan.getScheduledTime()),
                     aiPlan.getPlan().getPriority(),
                     aiPlan.isDone()
             );

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
@@ -3,6 +3,7 @@ package com.miruni.backend.domain.plan.dto.response;
 import com.miruni.backend.domain.plan.entity.AiPlan;
 import com.miruni.backend.domain.plan.entity.BasicPlan;
 import com.miruni.backend.domain.plan.entity.Priority;
+import com.miruni.backend.domain.plan.type.PlanType;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -20,7 +21,7 @@ public record DailyPlanResponse(
     }
 
     public record DailyPlanItemResponse(
-            String planType,
+            PlanType planType,
             Long planId,
             String title,
             String subTitle,
@@ -30,7 +31,7 @@ public record DailyPlanResponse(
     ) {
         public static DailyPlanItemResponse fromBasic(BasicPlan plan) {
             return new DailyPlanItemResponse(
-                    "BASIC",
+                    PlanType.BASIC,
                     plan.getId(),
                     plan.getTitle(),
                     null,
@@ -42,7 +43,7 @@ public record DailyPlanResponse(
 
         public static DailyPlanItemResponse fromAi(AiPlan aiPlan) {
             return new DailyPlanItemResponse(
-                    "AI",
+                    PlanType.AI,
                     aiPlan.getId(),
                     aiPlan.getPlan().getTitle(), // TODO
                     aiPlan.getSubTitle(),

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/MonthlyPlanResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/MonthlyPlanResponse.java
@@ -6,4 +6,10 @@ public record MonthlyPlanResponse(
         LocalDate date,
         long unfinishedPlanCount
 ) {
+    public static MonthlyPlanResponse of(LocalDate date, long count) {
+        return new MonthlyPlanResponse(
+                date,
+                count
+        );
+    }
 }

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/MonthlyPlanResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/MonthlyPlanResponse.java
@@ -1,0 +1,9 @@
+package com.miruni.backend.domain.plan.dto.response;
+
+import java.time.LocalDate;
+
+public record MonthlyPlanResponse(
+        LocalDate date,
+        long unfinishedPlanCount
+) {
+}

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/PlanDetailResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/PlanDetailResponse.java
@@ -1,0 +1,45 @@
+package com.miruni.backend.domain.plan.dto.response;
+
+import com.miruni.backend.domain.plan.entity.AiPlan;
+import com.miruni.backend.domain.plan.entity.BasicPlan;
+import com.miruni.backend.domain.plan.entity.Priority;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record PlanDetailResponse(
+        String planType,
+        Long planId,
+        String title,
+        String subTitle, // AI
+        String description, // BASIC
+        LocalDate scheduledDate,
+        LocalTime scheduledTime,
+        Priority priority
+) {
+    public static PlanDetailResponse fromBasic(BasicPlan basicPlan) {
+        return new PlanDetailResponse(
+                "BASIC",
+                basicPlan.getId(),
+                basicPlan.getTitle(),
+                null,
+                basicPlan.getDescription(),
+                basicPlan.getScheduledDate(),
+                basicPlan.getScheduledTime(),
+                basicPlan.getPriority()
+        );
+    }
+
+    public static PlanDetailResponse fromAi(AiPlan aiPlan) {
+        return new PlanDetailResponse(
+                "AI",
+                aiPlan.getId(),
+                aiPlan.getPlan().getTitle(),
+                aiPlan.getSubTitle(),
+                null,
+                aiPlan.getScheduledDate(),
+                aiPlan.getScheduledTime(),
+                aiPlan.getPlan().getPriority()
+        );
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/PlanDetailResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/PlanDetailResponse.java
@@ -6,7 +6,9 @@ import com.miruni.backend.domain.plan.entity.Priority;
 import com.miruni.backend.domain.plan.type.PlanType;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
+
+import static com.miruni.backend.global.common.DateTimeFormatUtil.formatTime;
+
 
 public record PlanDetailResponse(
         PlanType planType,
@@ -15,7 +17,7 @@ public record PlanDetailResponse(
         String subTitle, // AI
         String description, // BASIC
         LocalDate scheduledDate,
-        LocalTime scheduledTime,
+        String scheduledTime,
         Priority priority
 ) {
     public static PlanDetailResponse fromBasic(BasicPlan basicPlan) {
@@ -26,7 +28,7 @@ public record PlanDetailResponse(
                 null,
                 basicPlan.getDescription(),
                 basicPlan.getScheduledDate(),
-                basicPlan.getScheduledTime(),
+                formatTime(basicPlan.getScheduledTime()),
                 basicPlan.getPriority()
         );
     }
@@ -39,7 +41,7 @@ public record PlanDetailResponse(
                 aiPlan.getSubTitle(),
                 null,
                 aiPlan.getScheduledDate(),
-                aiPlan.getScheduledTime(),
+                formatTime(aiPlan.getScheduledTime()),
                 aiPlan.getPlan().getPriority()
         );
     }

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/PlanDetailResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/PlanDetailResponse.java
@@ -3,12 +3,13 @@ package com.miruni.backend.domain.plan.dto.response;
 import com.miruni.backend.domain.plan.entity.AiPlan;
 import com.miruni.backend.domain.plan.entity.BasicPlan;
 import com.miruni.backend.domain.plan.entity.Priority;
+import com.miruni.backend.domain.plan.type.PlanType;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record PlanDetailResponse(
-        String planType,
+        PlanType planType,
         Long planId,
         String title,
         String subTitle, // AI
@@ -19,7 +20,7 @@ public record PlanDetailResponse(
 ) {
     public static PlanDetailResponse fromBasic(BasicPlan basicPlan) {
         return new PlanDetailResponse(
-                "BASIC",
+                PlanType.BASIC,
                 basicPlan.getId(),
                 basicPlan.getTitle(),
                 null,
@@ -32,7 +33,7 @@ public record PlanDetailResponse(
 
     public static PlanDetailResponse fromAi(AiPlan aiPlan) {
         return new PlanDetailResponse(
-                "AI",
+                PlanType.AI,
                 aiPlan.getId(),
                 aiPlan.getPlan().getTitle(),
                 aiPlan.getSubTitle(),

--- a/src/main/java/com/miruni/backend/domain/plan/entity/AiPlan.java
+++ b/src/main/java/com/miruni/backend/domain/plan/entity/AiPlan.java
@@ -20,7 +20,7 @@ public class AiPlan extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "schedule_id", nullable = false)
+    @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
 
     @Column(name = "sub_title", nullable = false, length = 50)

--- a/src/main/java/com/miruni/backend/domain/plan/exception/AiPlanErrorCode.java
+++ b/src/main/java/com/miruni/backend/domain/plan/exception/AiPlanErrorCode.java
@@ -11,7 +11,7 @@ public enum AiPlanErrorCode implements ErrorCode {
     AI_RESPONSE_EMPTY(HttpStatus.BAD_GATEWAY,"AI_PLAN_001", "AI 로부터 유효한 응답을 받지 못했습니다."),
     AI_RESPONSE_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI_PLAN_002", "AI 응답을 파싱하는 데 실패했습니다."),
     AI_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "AI_PLAN404_1", "해당 AI 계획이 존재하지 않습니다."),
-    PLAN_FORBIDDEN(HttpStatus.FORBIDDEN, "AI_PLAN403_1", "해당 일정에 대한 권한이 없습니다.");
+    AI_PLAN_FORBIDDEN(HttpStatus.FORBIDDEN, "AI_PLAN403_1", "해당 일정에 대한 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/com/miruni/backend/domain/plan/exception/BasicPlanErrorCode.java
+++ b/src/main/java/com/miruni/backend/domain/plan/exception/BasicPlanErrorCode.java
@@ -11,8 +11,9 @@ public enum BasicPlanErrorCode implements ErrorCode {
 
     INVALID_PRIORITY_VALUE(HttpStatus.BAD_REQUEST, "BASICPLAN400_1", "잘못된 우선순위 값입니다. 우선순위 값은 '상', '중', '하' 중 하나여야 합니다."),
     INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "BASICPLAN400_2", "일정 시작 시각은 종료 시각보다 이전이어야 합니다."),
+    BASIC_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "BASICPLAN400_3", "일정을 찾을 수 없습니다."),
+    BASIC_PLAN_FORBIDDEN(HttpStatus.FORBIDDEN, "BASICPLAN403_1", "해당 일정에 대한 권한이 없습니다.");
 
-    BASIC_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "BASICPLAN400_3", "일정을 찾을 수 없습니다.");
     private final HttpStatus status;
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/miruni/backend/domain/plan/repository/AiPlanRepository.java
+++ b/src/main/java/com/miruni/backend/domain/plan/repository/AiPlanRepository.java
@@ -30,4 +30,16 @@ public interface AiPlanRepository extends JpaRepository<AiPlan, Long> {
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate
     );
+
+    @Query("""
+        SELECT a
+        FROM AiPlan a
+        WHERE a.plan.user.id = :userId
+          AND a.scheduledDate = :date
+        ORDER BY a.scheduledTime
+    """)
+    List<AiPlan> findDailyAiPlans(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date
+    );
 }

--- a/src/main/java/com/miruni/backend/domain/plan/repository/AiPlanRepository.java
+++ b/src/main/java/com/miruni/backend/domain/plan/repository/AiPlanRepository.java
@@ -1,9 +1,33 @@
 package com.miruni.backend.domain.plan.repository;
 
+import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
 import com.miruni.backend.domain.plan.entity.AiPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface AiPlanRepository extends JpaRepository<AiPlan, Long> {
+
+    @Query("""
+        SELECT new com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse(
+            a.scheduledDate,
+            COUNT(a)
+        )
+        FROM AiPlan a
+        WHERE a.plan.user.id = :userId
+          AND a.isDone = false
+          AND a.scheduledDate BETWEEN :startDate AND :endDate
+        GROUP BY a.scheduledDate
+        ORDER BY a.scheduledDate
+    """)
+    List<MonthlyPlanResponse> countUnfinishedAiPlansByDate(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 }

--- a/src/main/java/com/miruni/backend/domain/plan/repository/BasicPlanRepository.java
+++ b/src/main/java/com/miruni/backend/domain/plan/repository/BasicPlanRepository.java
@@ -1,12 +1,35 @@
 package com.miruni.backend.domain.plan.repository;
 
+import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
 import com.miruni.backend.domain.plan.entity.BasicPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface BasicPlanRepository extends JpaRepository<BasicPlan, Long> {
     Optional<BasicPlan> findByIdAndUserId(Long id, Long userId);
+
+    @Query("""
+        SELECT new com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse(
+             b.scheduledDate,
+             COUNT(b)
+         )
+        FROM BasicPlan b
+        WHERE b.user.id = :userId
+          AND b.isDone = false
+          AND b.scheduledDate BETWEEN :startDate AND :endDate
+        GROUP BY b.scheduledDate
+        ORDER BY b.scheduledDate
+    """)
+    List<MonthlyPlanResponse> countUnfinishedBasicPlansByDate(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 }

--- a/src/main/java/com/miruni/backend/domain/plan/repository/BasicPlanRepository.java
+++ b/src/main/java/com/miruni/backend/domain/plan/repository/BasicPlanRepository.java
@@ -32,4 +32,17 @@ public interface BasicPlanRepository extends JpaRepository<BasicPlan, Long> {
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate
     );
+
+
+    @Query("""
+        SELECT b
+        FROM BasicPlan b
+        WHERE b.user.id = :userId
+          AND b.scheduledDate = :date
+        ORDER BY b.scheduledTime
+    """)
+    List<BasicPlan> findDailyBasicPlans(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date
+    );
 }

--- a/src/main/java/com/miruni/backend/domain/plan/service/AiPlanCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/AiPlanCommandService.java
@@ -64,7 +64,7 @@ public class AiPlanCommandService {
         Plan plan = aiPlan.getPlan();
 
         if(!plan.getUser().getId().equals(user.getId())) {
-            throw BaseException.type(AiPlanErrorCode.PLAN_FORBIDDEN);
+            throw BaseException.type(AiPlanErrorCode.AI_PLAN_FORBIDDEN);
         }
 
         plan.updateTitle(request.title());
@@ -81,7 +81,7 @@ public class AiPlanCommandService {
         User user = userRepository.findById(user_id).orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
 
         if (!aiPlan.getPlan().getUser().getId().equals(user.getId())) {
-            throw BaseException.type(AiPlanErrorCode.PLAN_FORBIDDEN);
+            throw BaseException.type(AiPlanErrorCode.AI_PLAN_FORBIDDEN);
         }
         aiPlanRepository.delete(aiPlan);
 

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
@@ -2,10 +2,18 @@ package com.miruni.backend.domain.plan.service;
 
 import com.miruni.backend.domain.plan.dto.response.DailyPlanResponse;
 import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
+import com.miruni.backend.domain.plan.dto.response.PlanDetailResponse;
+import com.miruni.backend.domain.plan.entity.AiPlan;
+import com.miruni.backend.domain.plan.entity.BasicPlan;
+import com.miruni.backend.domain.plan.exception.AiPlanErrorCode;
+import com.miruni.backend.domain.plan.exception.BasicPlanErrorCode;
 import com.miruni.backend.domain.plan.repository.AiPlanRepository;
 import com.miruni.backend.domain.plan.repository.BasicPlanRepository;
+import com.miruni.backend.global.exception.BaseException;
+import com.miruni.backend.global.exception.CommonErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.Comparator;
@@ -16,6 +24,7 @@ import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PlanQueryService {
 
     private final AiPlanRepository aiPlanRepository;
@@ -63,5 +72,36 @@ public class PlanQueryService {
                 .collect(Collectors.partitioningBy(DailyPlanResponse.DailyPlanItemResponse::isDone));
 
         return DailyPlanResponse.of(plansByStatus.get(false), plansByStatus.get(true));
+    }
+
+    /**
+     * 일정 상세 조회
+     */
+    public PlanDetailResponse getPlanDetail(Long userId, Long planId, String planType) {
+        return switch (planType) {
+            case "BASIC" -> getBasicPlanDetail(userId, planId);
+            case "AI" -> getAiPlanDetail(userId, planId);
+            default -> throw BaseException.type(CommonErrorCode.INVALID_REQUEST);
+        };
+    }
+
+    private PlanDetailResponse getBasicPlanDetail(Long userId, Long planId) {
+        BasicPlan basicPlan = basicPlanRepository.findById(planId)
+                .orElseThrow(() -> BaseException.type(BasicPlanErrorCode.BASIC_PLAN_NOT_FOUND));
+
+        if (!userId.equals(basicPlan.getUser().getId())) {
+            throw BaseException.type(BasicPlanErrorCode.BASIC_PLAN_FORBIDDEN);
+        }
+        return PlanDetailResponse.fromBasic(basicPlan);
+    }
+
+    private PlanDetailResponse getAiPlanDetail(Long userId, Long planId) {
+        AiPlan aiPlan = aiPlanRepository.findById(planId)
+                .orElseThrow(() -> BaseException.type(AiPlanErrorCode.AI_PLAN_NOT_FOUND));
+
+        if (!userId.equals(aiPlan.getPlan().getUser().getId())) {
+            throw BaseException.type(AiPlanErrorCode.AI_PLAN_FORBIDDEN);
+        }
+        return PlanDetailResponse.fromAi(aiPlan);
     }
 }

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
@@ -1,0 +1,40 @@
+package com.miruni.backend.domain.plan.service;
+
+import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
+import com.miruni.backend.domain.plan.repository.AiPlanRepository;
+import com.miruni.backend.domain.plan.repository.BasicPlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class PlanQueryService {
+
+    private final AiPlanRepository aiPlanRepository;
+    private final BasicPlanRepository basicPlanRepository;
+
+    public List<MonthlyPlanResponse> getMonthlyPlan(Long userId, int year, int month) {
+
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        List<MonthlyPlanResponse> basicPlans = basicPlanRepository.countUnfinishedBasicPlansByDate(userId, startDate, endDate);
+        List<MonthlyPlanResponse> aiPlans = aiPlanRepository.countUnfinishedAiPlansByDate(userId, startDate, endDate);
+
+        return Stream.concat(basicPlans.stream(), aiPlans.stream())
+                .collect(Collectors.groupingBy(
+                        MonthlyPlanResponse::date,
+                        Collectors.summingLong(MonthlyPlanResponse::unfinishedPlanCount)
+                ))
+                .entrySet().stream()
+                .map(e -> new MonthlyPlanResponse(e.getKey(), e.getValue()))
+                .sorted(Comparator.comparing(MonthlyPlanResponse::date))
+                .toList();
+    }
+}

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
@@ -50,7 +50,7 @@ public class PlanQueryService {
 
         LocalDate date = LocalDate.of(year, month, day);
 
-        List<DailyPlanResponse.DailyPlanItemResponse> allPlans = Stream.concat(
+        List<DailyPlanResponse.DailyPlanItemResponse> plans = Stream.concat(
                 basicPlanRepository.findDailyBasicPlans(userId, date).stream()
                         .map(DailyPlanResponse.DailyPlanItemResponse::fromBasic),
                 aiPlanRepository.findDailyAiPlans(userId, date).stream()
@@ -58,7 +58,7 @@ public class PlanQueryService {
         ).toList();
 
         Map<Boolean, List<DailyPlanResponse.DailyPlanItemResponse>> plansByStatus =
-                allPlans.stream()
+                plans.stream()
                         .collect(Collectors.partitioningBy(DailyPlanResponse.DailyPlanItemResponse::isDone));
         // TODO: scheduledTime으로 정렬 추가할 것
 

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
@@ -21,6 +21,9 @@ public class PlanQueryService {
     private final AiPlanRepository aiPlanRepository;
     private final BasicPlanRepository basicPlanRepository;
 
+    /**
+     * 캘린더 조회
+     */
     public List<MonthlyPlanResponse> getMonthlyPlan(Long userId, int year, int month) {
 
         LocalDate startDate = LocalDate.of(year, month, 1);
@@ -35,11 +38,14 @@ public class PlanQueryService {
                         Collectors.summingLong(MonthlyPlanResponse::unfinishedPlanCount)
                 ))
                 .entrySet().stream()
-                .map(e -> new MonthlyPlanResponse(e.getKey(), e.getValue()))
+                .map(e -> MonthlyPlanResponse.of(e.getKey(), e.getValue()))
                 .sorted(Comparator.comparing(MonthlyPlanResponse::date))
                 .toList();
     }
 
+    /**
+     * (캘린더 아래) 특정 날짜의 일정 조회
+     */
     public DailyPlanResponse getDailyPlan(Long userId, int year, int month, int day) {
 
         LocalDate date = LocalDate.of(year, month, day);
@@ -56,9 +62,6 @@ public class PlanQueryService {
                         .collect(Collectors.partitioningBy(DailyPlanResponse.DailyPlanItemResponse::isDone));
         // TODO: scheduledTime으로 정렬 추가할 것
 
-        return new DailyPlanResponse(
-                plansByStatus.get(false),
-                plansByStatus.get(true)
-        );
+        return DailyPlanResponse.of(plansByStatus.get(false), plansByStatus.get(true));
     }
 }

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
@@ -1,14 +1,19 @@
 package com.miruni.backend.domain.plan.service;
 
+import com.miruni.backend.domain.plan.dto.response.DailyPlanResponse;
 import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
+import com.miruni.backend.domain.plan.entity.AiPlan;
+import com.miruni.backend.domain.plan.entity.BasicPlan;
 import com.miruni.backend.domain.plan.repository.AiPlanRepository;
 import com.miruni.backend.domain.plan.repository.BasicPlanRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -36,5 +41,27 @@ public class PlanQueryService {
                 .map(e -> new MonthlyPlanResponse(e.getKey(), e.getValue()))
                 .sorted(Comparator.comparing(MonthlyPlanResponse::date))
                 .toList();
+    }
+
+    public DailyPlanResponse getDailyPlan(Long userId, int year, int month, int day) {
+
+        LocalDate date = LocalDate.of(year, month, day);
+
+        List<DailyPlanResponse.DailyPlanItemResponse> allPlans = Stream.concat(
+                basicPlanRepository.findDailyBasicPlans(userId, date).stream()
+                        .map(DailyPlanResponse.DailyPlanItemResponse::fromBasic),
+                aiPlanRepository.findDailyAiPlans(userId, date).stream()
+                        .map(DailyPlanResponse.DailyPlanItemResponse::fromAi)
+        ).toList();
+
+        Map<Boolean, List<DailyPlanResponse.DailyPlanItemResponse>> plansByStatus =
+                allPlans.stream()
+                        .collect(Collectors.partitioningBy(DailyPlanResponse.DailyPlanItemResponse::isDone));
+        // TODO: scheduledTime으로 정렬 추가할 것
+
+        return new DailyPlanResponse(
+                plansByStatus.get(false),
+                plansByStatus.get(true)
+        );
     }
 }

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
@@ -2,15 +2,12 @@ package com.miruni.backend.domain.plan.service;
 
 import com.miruni.backend.domain.plan.dto.response.DailyPlanResponse;
 import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
-import com.miruni.backend.domain.plan.entity.AiPlan;
-import com.miruni.backend.domain.plan.entity.BasicPlan;
 import com.miruni.backend.domain.plan.repository.AiPlanRepository;
 import com.miruni.backend.domain.plan.repository.BasicPlanRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
@@ -9,6 +9,7 @@ import com.miruni.backend.domain.plan.exception.AiPlanErrorCode;
 import com.miruni.backend.domain.plan.exception.BasicPlanErrorCode;
 import com.miruni.backend.domain.plan.repository.AiPlanRepository;
 import com.miruni.backend.domain.plan.repository.BasicPlanRepository;
+import com.miruni.backend.domain.plan.type.PlanType;
 import com.miruni.backend.global.exception.BaseException;
 import com.miruni.backend.global.exception.CommonErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -77,10 +78,10 @@ public class PlanQueryService {
     /**
      * 일정 상세 조회
      */
-    public PlanDetailResponse getPlanDetail(Long userId, Long planId, String planType) {
+    public PlanDetailResponse getPlanDetail(Long userId, Long planId, PlanType planType) {
         return switch (planType) {
-            case "BASIC" -> getBasicPlanDetail(userId, planId);
-            case "AI" -> getAiPlanDetail(userId, planId);
+            case PlanType.BASIC -> getBasicPlanDetail(userId, planId);
+            case PlanType.AI -> getAiPlanDetail(userId, planId);
             default -> throw BaseException.type(CommonErrorCode.INVALID_REQUEST);
         };
     }

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
@@ -51,16 +51,16 @@ public class PlanQueryService {
         LocalDate date = LocalDate.of(year, month, day);
 
         List<DailyPlanResponse.DailyPlanItemResponse> plans = Stream.concat(
-                basicPlanRepository.findDailyBasicPlans(userId, date).stream()
-                        .map(DailyPlanResponse.DailyPlanItemResponse::fromBasic),
-                aiPlanRepository.findDailyAiPlans(userId, date).stream()
-                        .map(DailyPlanResponse.DailyPlanItemResponse::fromAi)
-        ).toList();
+                    basicPlanRepository.findDailyBasicPlans(userId, date).stream()
+                            .map(DailyPlanResponse.DailyPlanItemResponse::fromBasic),
+                    aiPlanRepository.findDailyAiPlans(userId, date).stream()
+                            .map(DailyPlanResponse.DailyPlanItemResponse::fromAi)
+                )
+                .sorted(Comparator.comparing(DailyPlanResponse.DailyPlanItemResponse::scheduledTime))
+                .toList();
 
-        Map<Boolean, List<DailyPlanResponse.DailyPlanItemResponse>> plansByStatus =
-                plans.stream()
-                        .collect(Collectors.partitioningBy(DailyPlanResponse.DailyPlanItemResponse::isDone));
-        // TODO: scheduledTime으로 정렬 추가할 것
+        Map<Boolean, List<DailyPlanResponse.DailyPlanItemResponse>> plansByStatus = plans.stream()
+                .collect(Collectors.partitioningBy(DailyPlanResponse.DailyPlanItemResponse::isDone));
 
         return DailyPlanResponse.of(plansByStatus.get(false), plansByStatus.get(true));
     }

--- a/src/main/java/com/miruni/backend/domain/plan/type/PlanType.java
+++ b/src/main/java/com/miruni/backend/domain/plan/type/PlanType.java
@@ -1,0 +1,5 @@
+package com.miruni.backend.domain.plan.type;
+
+public enum PlanType {
+    BASIC, AI
+}

--- a/src/main/java/com/miruni/backend/global/common/DateTimeFormatUtil.java
+++ b/src/main/java/com/miruni/backend/global/common/DateTimeFormatUtil.java
@@ -1,0 +1,35 @@
+package com.miruni.backend.global.common;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public final class DateTimeFormatUtil {
+
+    // 오전/오후 hh:mm formatter
+    public static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("a hh:mm", Locale.KOREAN);
+
+
+    public static String formatTime(LocalTime time) {
+        return time.format(TIME_FORMATTER);
+    }
+
+    public static String formatTime(LocalDateTime dateTime) {
+        return dateTime.format(TIME_FORMATTER);
+    }
+
+    // yyyy.MM.dd formatter
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    public static String formatDate(LocalDateTime dateTime) {
+        return dateTime.format(DATE_FORMATTER);
+    }
+
+    // yyyy.MM.dd 오전/오후 hh:mm formatter
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd a hh:mm", Locale.KOREAN);
+
+    public static String formatDateTime(LocalDateTime dateTime) {
+        return dateTime.format(DATE_TIME_FORMATTER);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #21
<!-- 이슈 완료되었을 때만 close 붙여주세요 -->

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->

- 캘린더 페이지에 필요한 조회 API 구현
    - 캘린더 조회 (날짜별 미완료 일정 개수 조회)
    - 날짜별 일정 조회 
    - 상세 일정 조회

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
AiPlan 엔티티에서 외래키 컬럼명 통일성을 위해서 schedule_id -> plan_id으로 바꿨습니다. DB초기화해주세용

그리고 같이 정하고 싶은게 있는데..

### 1. Plan 서비스단
도메인 간 참조를 줄이자고 했는데 PlanQueryService에서 BasicPlan, AiPlan 레포지토리를 직접 참조하도록 구현해서 리팩토링을 해야할 것 같습니다 (새로 브랜치 파서 하려고 합니닷)
근데 그러려면 각 도메인에 해당하는 queryService에 메서드를 두고, 상위 서비스를 하나 만들어서 호출하게 해야 하는데 이때 서비스명을 뭐라고 해야 할까요? PlanQueryService로 하려 했는데 Plan테이블이 있는 상황이라 다시 도메인 구조가 안 맞을 것 같기도 해서 고민입니다 .....
그리고 혹시 요부분 전체 구조나 쿼리에 대해 다른 좋은 아이디어가 있다면 공유해주세요,,,,,

### 2. dto에서 객체 접근
dto에서 `aiPlan.getPlan().getTitle()` 같이 도메인을 두 번 타고 들어가는게 있는데, 이런 경우도 아래처럼 따로 중간 조회 메서드를 도메인에 두도록 컨벤션을 정하는게 좋을까요??
```java
  // AiPlan.java
  public String getPlanTitle() {
      return plan.getTitle();
  }

```
이렇게 중간 메서드를 도메인에 두면 `aiPlan.getPlanTitle()`  이런식으로 줄일 수 있을 것 같습니다