### PR TITLE
[feat] #24 소셜 로그인 api 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 src/main/resources/firebase/
+

--- a/src/main/java/com/miruni/backend/domain/user/controller/AuthApi.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/AuthApi.java
@@ -301,7 +301,7 @@ public interface AuthApi {
 
     @Operation(
             summary = "소셜 회원가입 완료",
-            description = "ROLE_GUEST 상태의 소셜 유저가 필수 약관 및 닉네임을 제출하여 최종 회원가입을 완료합니다."
+            description = "가입 미완료(ROLE_GUEST, PENDING_SIGNUP) 소셜 유저가 필수 약관 및 닉네임을 제출하여 최종 회원가입을 완료합니다."
     )
     @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "JWT")
     @ApiResponses({

--- a/src/main/java/com/miruni/backend/domain/user/controller/AuthApi.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/AuthApi.java
@@ -1,7 +1,12 @@
 package com.miruni.backend.domain.user.controller;
 
+import com.miruni.backend.domain.user.dto.request.GoogleLoginRequest;
+import com.miruni.backend.domain.user.dto.request.KakaoLoginRequest;
 import com.miruni.backend.domain.user.dto.request.LoginRequest;
+import com.miruni.backend.domain.user.dto.request.SocialSignupCompleteRequest;
 import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
+import com.miruni.backend.domain.user.dto.response.SocialLoginResponseDto;
+import com.miruni.backend.domain.user.entity.OauthProvider;
 import com.miruni.backend.global.authroize.AuthToken;
 import com.miruni.backend.global.authroize.LoginUser;
 import com.miruni.backend.global.exception.CustomErrorResponse;
@@ -13,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "인증 API", description = "로그인, 로그아웃 등 인증 관련 API")
@@ -146,5 +152,192 @@ public interface AuthApi {
     void logout(
             @AuthToken String accessToken,
             @LoginUser Long userId
+    );
+
+    @Operation(
+            summary = "구글 소셜 로그인",
+            description = "구글 ID 토큰으로 소셜 로그인을 수행하고, 신규/기존 여부 및 회원가입 필요 여부를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "소셜 로그인 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.miruni.backend.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                          "errorCode": null,
+                          "message": "OK",
+                          "result": {
+                            "signupRequired": true,
+                            "newUser": true,
+                            "tokens": {
+                              "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                              "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                              "tokenType": "Bearer",
+                              "accessTokenExpiresIn": 3600,
+                              "refreshTokenExpiresIn": 604800
+                            }
+                          }
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 구글 토큰",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "소셜 토큰 검증 실패",
+                                    value = """
+                        {
+                          "status": 401,
+                          "errorCode": "USER401_8",
+                          "message": "유효하지 않은 소셜 로그인 토큰입니다."
+                        }
+                        """
+                            )
+                    )
+            )
+    })
+    SocialLoginResponseDto loginWithGoogle(@Valid @RequestBody GoogleLoginRequest request);
+
+    @Operation(
+            summary = "카카오 소셜 로그인",
+            description = "카카오 액세스 토큰으로 소셜 로그인을 수행하고, 신규/기존 여부 및 회원가입 필요 여부를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "소셜 로그인 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.miruni.backend.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                          "errorCode": null,
+                          "message": "OK",
+                          "result": {
+                            "signupRequired": false,
+                            "newUser": false,
+                            "tokens": {
+                              "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                              "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                              "tokenType": "Bearer",
+                              "accessTokenExpiresIn": 3600,
+                              "refreshTokenExpiresIn": 604800
+                            }
+                          }
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 카카오 토큰",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "소셜 토큰 검증 실패",
+                                    value = """
+                        {
+                          "status": 401,
+                          "errorCode": "USER401_8",
+                          "message": "유효하지 않은 소셜 로그인 토큰입니다."
+                        }
+                        """
+                            )
+                    )
+            )
+    })
+    SocialLoginResponseDto loginWithKakao(@Valid @RequestBody KakaoLoginRequest request);
+
+    @Operation(
+            summary = "소셜 회원가입 완료",
+            description = "ROLE_GUEST 상태의 소셜 유저가 필수 약관 및 닉네임을 제출하여 최종 회원가입을 완료합니다."
+    )
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "JWT")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 완료 및 JWT 발급 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.miruni.backend.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                          "errorCode": null,
+                          "message": "OK",
+                          "result": {
+                            "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                            "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                            "tokenType": "Bearer",
+                            "accessTokenExpiresIn": 3600,
+                            "refreshTokenExpiresIn": 604800
+                          }
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "입력값 검증 실패 또는 약관/닉네임 관련 오류",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "약관 미동의",
+                                            value = """
+                        {
+                          "status": 400,
+                          "errorCode": "USER400_5",
+                          "message": "필수 약관에 동의해야 합니다."
+                        }
+                        """
+                                    ),
+                                    @ExampleObject(
+                                            name = "닉네임 중복",
+                                            value = """
+                        {
+                          "status": 400,
+                          "errorCode": "USER404_1",
+                          "message": "이미 사용 중인 닉네임입니다."
+                        }
+                        """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "JWT 인증 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "인증 실패",
+                                    value = """
+                        {
+                          "status": 401,
+                          "errorCode": "COMMON_003",
+                          "message": "인증이 필요합니다."
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "사용자 없음",
+                                    value = """
+                        {
+                          "status": 404,
+                          "errorCode": "USER404_3",
+                          "message": "사용자를 찾을 수 없습니다."
+                        }
+                        """
+                            )
+                    )
+            )
+    })
+    JwtResponseDto completeSocialSignup(
+            @PathVariable("provider") OauthProvider provider,
+            @LoginUser Long userId,
+            @Valid @RequestBody SocialSignupCompleteRequest request
     );
 }

--- a/src/main/java/com/miruni/backend/domain/user/controller/AuthApi.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/AuthApi.java
@@ -3,6 +3,7 @@ package com.miruni.backend.domain.user.controller;
 import com.miruni.backend.domain.user.dto.request.GoogleLoginRequest;
 import com.miruni.backend.domain.user.dto.request.KakaoLoginRequest;
 import com.miruni.backend.domain.user.dto.request.LoginRequest;
+import com.miruni.backend.domain.user.dto.request.ReissueTokenRequest;
 import com.miruni.backend.domain.user.dto.request.SocialSignupCompleteRequest;
 import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
 import com.miruni.backend.domain.user.dto.response.SocialLoginResponseDto;
@@ -97,6 +98,54 @@ public interface AuthApi {
             )
     })
     JwtResponseDto login(@Valid @RequestBody LoginRequest request);
+
+    @Operation(
+            summary = "액세스/리프레시 토큰 재발급",
+            description = "유효한 리프레시 토큰을 가진 인증된 사용자에게 새로운 액세스/리프레시 토큰 세트를 발급합니다. (Refresh Token Rotation)"
+    )
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "JWT")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.miruni.backend.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                          "errorCode": null,
+                          "message": "OK",
+                          "result": {
+                            "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+                            "refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...",
+                            "tokenType": "Bearer",
+                            "accessTokenExpiresIn": 3600,
+                            "refreshTokenExpiresIn": 604800
+                          }
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "유효하지 않은 리프레시 토큰",
+                                    value = """
+                        {
+                          "status": 401,
+                          "errorCode": "USER401_6",
+                          "message": "유효하지 않은 토큰입니다."
+                        }
+                        """
+                            )
+                    )
+            )
+    })
+    JwtResponseDto refreshToken(
+            @LoginUser Long userId,
+            @Valid @RequestBody ReissueTokenRequest request
+    );
 
     @Operation(
             summary = "로그아웃",

--- a/src/main/java/com/miruni/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/AuthController.java
@@ -1,7 +1,12 @@
 package com.miruni.backend.domain.user.controller;
 
+import com.miruni.backend.domain.user.dto.request.GoogleLoginRequest;
+import com.miruni.backend.domain.user.dto.request.KakaoLoginRequest;
 import com.miruni.backend.domain.user.dto.request.LoginRequest;
+import com.miruni.backend.domain.user.dto.request.SocialSignupCompleteRequest;
 import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
+import com.miruni.backend.domain.user.dto.response.SocialLoginResponseDto;
+import com.miruni.backend.domain.user.entity.OauthProvider;
 import com.miruni.backend.domain.user.service.AuthCommandService;
 import com.miruni.backend.global.authroize.AuthToken;
 import com.miruni.backend.global.authroize.LoginUser;
@@ -29,6 +34,28 @@ public class AuthController implements AuthApi {
     @DeleteMapping("/token")
     public void logout(@AuthToken String accessToken, @LoginUser Long userId) {
         authCommandService.logout(accessToken, userId);
+    }
+
+    // 구글 소셜 로그인 API
+    @PostMapping("/social/google")
+    public SocialLoginResponseDto loginWithGoogle(@Valid @RequestBody GoogleLoginRequest request) {
+        return authCommandService.loginWithGoogle(request);
+    }
+
+    // 카카오 소셜 로그인 API
+    @PostMapping("/social/kakao")
+    public SocialLoginResponseDto loginWithKakao(@Valid @RequestBody KakaoLoginRequest request) {
+        return authCommandService.loginWithKakao(request);
+    }
+
+    // 소셜 로그인 완료(회원가입 완료) API
+    @PatchMapping("/social/{provider}")
+    public JwtResponseDto completeSocialSignup(
+            @PathVariable("provider") OauthProvider provider,
+            @LoginUser Long userId,
+            @Valid @RequestBody SocialSignupCompleteRequest request
+    ) {
+        return authCommandService.completeSocialSignup(provider, userId, request);
     }
 
 }

--- a/src/main/java/com/miruni/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.miruni.backend.domain.user.controller;
 import com.miruni.backend.domain.user.dto.request.GoogleLoginRequest;
 import com.miruni.backend.domain.user.dto.request.KakaoLoginRequest;
 import com.miruni.backend.domain.user.dto.request.LoginRequest;
+import com.miruni.backend.domain.user.dto.request.ReissueTokenRequest;
 import com.miruni.backend.domain.user.dto.request.SocialSignupCompleteRequest;
 import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
 import com.miruni.backend.domain.user.dto.response.SocialLoginResponseDto;
@@ -28,6 +29,15 @@ public class AuthController implements AuthApi {
     @PostMapping("/token")
     public JwtResponseDto login(@Valid @RequestBody LoginRequest request) {
         return authCommandService.login(request);
+    }
+
+    // 액세스/리프레시 토큰 재발급 API
+    @PostMapping("/token/refresh")
+    public JwtResponseDto refreshToken(
+            @LoginUser Long userId,
+            @Valid @RequestBody ReissueTokenRequest request
+    ) {
+        return authCommandService.reissueToken(userId, request.refreshToken());
     }
 
     // 일반 로그아웃 API

--- a/src/main/java/com/miruni/backend/domain/user/controller/SurveyApi.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/SurveyApi.java
@@ -1,5 +1,92 @@
 package com.miruni.backend.domain.user.controller;
 
+import com.miruni.backend.domain.user.dto.request.SurveyRequest;
+import com.miruni.backend.domain.user.dto.response.SurveyResponse;
+import com.miruni.backend.domain.user.dto.response.UserSurveyResponse;
+import com.miruni.backend.global.authroize.LoginUser;
+import com.miruni.backend.global.exception.CustomErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "설문조사 API", description = "사용자 설문조사 조회/수정 API")
 public interface SurveyApi {
-    
+
+    @Operation(
+            summary = "사용자 설문조사 결과 조회",
+            description = "현재 로그인한 사용자의 설문조사 결과를 조회합니다."
+    )
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "JWT")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.miruni.backend.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                          "errorCode": null,
+                          "message": "OK",
+                          "result": {
+                            "situationDescriptions": ["PHONE"],
+                            "delayRange": 3,
+                            "reasonDescriptions": ["PERFECTIONISM"]
+                          }
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "사용자 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class))
+            )
+    })
+    UserSurveyResponse getUserSurveyResult(@LoginUser Long userId);
+
+    @Operation(
+            summary = "사용자 설문조사 수정/저장",
+            description = "현재 로그인한 사용자의 설문조사 내용을 저장하거나 수정합니다."
+    )
+    @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "JWT")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정/저장 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = com.miruni.backend.global.response.ApiResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답",
+                                    value = """
+                        {
+                          "errorCode": null,
+                          "message": "OK",
+                          "result": {
+                            "message": "설문조사가 수정되었습니다!",
+                            "completedAt": "2024-01-01T12:00:00",
+                            "status": "UPDATED"
+                          }
+                        }
+                        """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "입력값 검증 실패",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "사용자 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomErrorResponse.class))
+            )
+    })
+    SurveyResponse updateSurvey(
+            @LoginUser Long userId,
+            @Valid @RequestBody SurveyRequest request
+    );
 }
+

--- a/src/main/java/com/miruni/backend/domain/user/controller/SurveyController.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/SurveyController.java
@@ -1,5 +1,39 @@
 package com.miruni.backend.domain.user.controller;
 
-public class SurveyController {
-    
+import com.miruni.backend.domain.user.dto.request.SurveyRequest;
+import com.miruni.backend.domain.user.dto.response.SurveyResponse;
+import com.miruni.backend.domain.user.dto.response.UserSurveyResponse;
+import com.miruni.backend.domain.user.service.UserCommandService;
+import com.miruni.backend.domain.user.service.UserQueryService;
+import com.miruni.backend.global.authroize.LoginUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/surveys")
+@RequiredArgsConstructor
+@Validated
+public class SurveyController implements SurveyApi {
+
+    private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
+
+    @Override
+    @GetMapping
+    public UserSurveyResponse getUserSurveyResult(@LoginUser Long userId) {
+        return userQueryService.getUserSurveyResult(userId);
+    }
+
+    @Override
+    @PatchMapping
+    public SurveyResponse updateSurvey(@LoginUser Long userId, @RequestBody @Valid SurveyRequest request) {
+        return userCommandService.updateSurvey(request, userId);
+    }
 }
+

--- a/src/main/java/com/miruni/backend/domain/user/controller/SurveyController.java
+++ b/src/main/java/com/miruni/backend/domain/user/controller/SurveyController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/surveys")
 @RequiredArgsConstructor
-@Validated
 public class SurveyController implements SurveyApi {
 
     private final UserQueryService userQueryService;

--- a/src/main/java/com/miruni/backend/domain/user/dto/AuthUserInfoDto.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/AuthUserInfoDto.java
@@ -1,0 +1,16 @@
+package com.miruni.backend.domain.user.dto;
+
+/**
+ * 소셜 로그인으로부터 얻은 사용자 기본 정보 DTO
+ */
+public record AuthUserInfoDto(
+        String email,
+        String name
+) {
+
+    public static AuthUserInfoDto of(String email, String name) {
+        return new AuthUserInfoDto(email, name);
+    }
+}
+
+

--- a/src/main/java/com/miruni/backend/domain/user/dto/request/GoogleLoginRequest.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/request/GoogleLoginRequest.java
@@ -1,0 +1,15 @@
+package com.miruni.backend.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "구글 소셜 로그인 요청 DTO")
+public record GoogleLoginRequest(
+
+        @NotBlank(message = "Google ID 토큰은 필수입니다.")
+        @Schema(description = "Google ID Token", example = "eyJhbGciOiJSUzI1NiIsImtpZCI6Ij...")
+        String googleIdToken
+) {
+}
+
+

--- a/src/main/java/com/miruni/backend/domain/user/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,15 @@
+package com.miruni.backend.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "카카오 소셜 로그인 요청 DTO")
+public record KakaoLoginRequest(
+
+        @NotBlank(message = "카카오 액세스 토큰은 필수입니다.")
+        @Schema(description = "카카오 액세스 토큰", example = "kakao-access-token")
+        String accessToken
+) {
+}
+
+

--- a/src/main/java/com/miruni/backend/domain/user/dto/request/ReissueTokenRequest.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/request/ReissueTokenRequest.java
@@ -1,0 +1,15 @@
+package com.miruni.backend.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "액세스/리프레시 토큰 재발급 요청 DTO")
+public record ReissueTokenRequest(
+
+        @NotBlank(message = "리프레시 토큰은 필수입니다.")
+        @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.tenup...")
+        String refreshToken
+) {
+}
+
+

--- a/src/main/java/com/miruni/backend/domain/user/dto/request/SocialSignupCompleteRequest.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/request/SocialSignupCompleteRequest.java
@@ -1,23 +1,12 @@
 package com.miruni.backend.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
-import io.swagger.v3.oas.annotations.media.Schema;
 
-public record UserSignupRequest(
-
-        @NotBlank(message = "이메일은 필수입니다.")
-        @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Size(max = 255, message = "이메일은 255자 이하여야 합니다.")
-        @Schema(description = "이메일 주소", example = "dhzktldh@gmail.com")
-        String email,
-
-        @NotBlank(message = "비밀번호는 필수입니다.")
-        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
-        @Schema(description = "비밀번호", example = "password123!")
-        String password,
+@Schema(description = "소셜 로그인 완료(회원가입 완료) 요청 DTO")
+public record SocialSignupCompleteRequest(
 
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(max = 20, message = "닉네임은 20자 이하여야 합니다.")
@@ -34,6 +23,7 @@ public record UserSignupRequest(
 
         @Schema(description = "마케팅 정보 수신 동의 (선택)", example = "false")
         Boolean marketingAgreed
-
 ) {
 }
+
+

--- a/src/main/java/com/miruni/backend/domain/user/dto/request/SurveyRequest.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/request/SurveyRequest.java
@@ -1,0 +1,36 @@
+package com.miruni.backend.domain.user.dto.request;
+
+import com.miruni.backend.domain.user.entity.DelayLevel;
+import com.miruni.backend.domain.user.entity.DelayReason;
+import com.miruni.backend.domain.user.entity.DelaySituation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.Set;
+
+@Schema(description = "설문조사 요청 DTO - enum 타입으로 응답")
+public record SurveyRequest(
+
+        @Schema(description = "첫 번째 질문: 어떤 상황에서 미루게 되나요? (복수선택)",
+                example = "[\"PHONE\", \"TOO_TIRED\"]")
+        @NotEmpty(message = "첫 번째 질문 응답은 필수입니다.")
+        @Size(min = 1, max = 5, message = "1-5개 항목을 선택해야 합니다.")
+        Set<DelaySituation> situations,
+
+        @Schema(description = "두 번째 질문: 평소 얼마나 미루는 편인가요?",
+                example = "NORMAL")
+        @NotNull(message = "두 번째 질문 응답은 필수입니다.")
+        DelayLevel level,
+
+        @Schema(description = "세 번째 질문: 미루는 주된 이유는 무엇인가요? (복수선택)",
+                example = "[\"PERFECTIONISM\", \"NOT_FUN\"]")
+        @NotEmpty(message = "세 번째 질문 응답은 필수입니다.")
+        @Size(min = 1, max = 6, message = "1-6개 항목을 선택해야 합니다.")
+        Set<DelayReason> reasons
+
+) {
+}
+
+

--- a/src/main/java/com/miruni/backend/domain/user/dto/response/SocialLoginResponseDto.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/response/SocialLoginResponseDto.java
@@ -1,0 +1,37 @@
+package com.miruni.backend.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "소셜 로그인 응답 DTO")
+public record SocialLoginResponseDto(
+
+        @Schema(description = "회원가입 추가 정보 입력 필요 여부")
+        boolean signupRequired,
+
+        @Schema(description = "이번 요청이 신규 소셜 유저인지 여부")
+        boolean isNewUser,
+
+        @Schema(description = "발급된 JWT 토큰 정보 (ROLE_GUEST 또는 ROLE_USER)")
+        JwtResponseDto tokens
+) {
+
+    public static SocialLoginResponseDto signupNeeded(JwtResponseDto tokens, boolean isNewUser) {
+        return SocialLoginResponseDto.builder()
+                .signupRequired(true)
+                .isNewUser(isNewUser)
+                .tokens(tokens)
+                .build();
+    }
+
+    public static SocialLoginResponseDto loggedIn(JwtResponseDto tokens, boolean isNewUser) {
+        return SocialLoginResponseDto.builder()
+                .signupRequired(false)
+                .isNewUser(isNewUser)
+                .tokens(tokens)
+                .build();
+    }
+}
+
+

--- a/src/main/java/com/miruni/backend/domain/user/dto/response/SocialLoginResponseDto.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/response/SocialLoginResponseDto.java
@@ -13,7 +13,7 @@ public record SocialLoginResponseDto(
         @Schema(description = "이번 요청이 신규 소셜 유저인지 여부")
         boolean isNewUser,
 
-        @Schema(description = "발급된 JWT 토큰 정보 (ROLE_GUEST 또는 ROLE_USER)")
+        @Schema(description = "발급된 JWT 토큰 정보 (가입 미완료는 ROLE_GUEST(PENDING_SIGNUP), 가입 완료는 ROLE_USER)")
         JwtResponseDto tokens
 ) {
 

--- a/src/main/java/com/miruni/backend/domain/user/dto/response/SurveyResponse.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/response/SurveyResponse.java
@@ -1,0 +1,25 @@
+package com.miruni.backend.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(description = "설문조사 수정/완료 응답")
+public record SurveyResponse(
+        @Schema(description = "메시지", example = "설문조사가 수정되었습니다!")
+        String message,
+
+        @Schema(description = "설문 완료/수정 시각")
+        LocalDateTime completedAt,
+
+        @Schema(description = "상태", example = "UPDATED")
+        String status
+) {
+    public static SurveyResponse of(String message, LocalDateTime completedAt, String status) {
+        return new SurveyResponse(message, completedAt, status);
+    }
+}
+
+

--- a/src/main/java/com/miruni/backend/domain/user/dto/response/SurveyResponse.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/response/SurveyResponse.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 
 import java.time.LocalDateTime;
 
-@Builder
 @Schema(description = "설문조사 수정/완료 응답")
 public record SurveyResponse(
         @Schema(description = "메시지", example = "설문조사가 수정되었습니다!")

--- a/src/main/java/com/miruni/backend/domain/user/dto/response/UserSurveyResponse.java
+++ b/src/main/java/com/miruni/backend/domain/user/dto/response/UserSurveyResponse.java
@@ -1,0 +1,45 @@
+package com.miruni.backend.domain.user.dto.response;
+
+import com.miruni.backend.domain.user.entity.DelayLevel;
+import com.miruni.backend.domain.user.entity.DelayReason;
+import com.miruni.backend.domain.user.entity.DelaySituation;
+import com.miruni.backend.domain.user.entity.Survey;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "사용자 설문조사 결과 응답")
+public record UserSurveyResponse(
+
+        @Schema(description = "미루는 상황들")
+        List<String> situationDescriptions,
+
+        @Schema(description = "미루는 정도 설명")
+        String levelDescription,
+
+        @Schema(description = "미루는 이유들")
+        List<String> reasonDescriptions
+
+) {
+
+    public static UserSurveyResponse fromSurvey(Survey survey) {
+        if (survey == null) {
+            return new UserSurveyResponse(List.of(), null, List.of());
+        }
+
+        List<String> situations = DelaySituation.fromMask(survey.getDelaySituationMask()).stream()
+                .map(DelaySituation::getDescription)
+                .toList();
+
+        List<String> reasons = DelayReason.fromMask(survey.getDelayReasonMask()).stream()
+                .map(DelayReason::getDescription)
+                .toList();
+
+        DelayLevel level = survey.getDelayLevel();
+        String levelDescription = (level != null) ? level.getDescription() : null;
+
+        return new UserSurveyResponse(situations, levelDescription, reasons);
+    }
+}
+
+

--- a/src/main/java/com/miruni/backend/domain/user/entity/DelayLevel.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/DelayLevel.java
@@ -1,0 +1,18 @@
+package com.miruni.backend.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DelayLevel {
+    NEVER("거의 미루지 않는다"),
+    RARELY("가끔 미룬다"),
+    NORMAL("보통이다"),
+    OFTEN("자주 미룬다"),
+    ALWAYS("항상 미룬다");
+
+    private final String description;
+}
+
+

--- a/src/main/java/com/miruni/backend/domain/user/entity/DelayReason.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/DelayReason.java
@@ -1,5 +1,50 @@
 package com.miruni.backend.domain.user.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum DelayReason {
-    Bored
+
+    LAZY(1, "귀찮아서"),
+    TOO_BIG_TO_START(2, "일이 너무 커 보여서(부담)"),
+    DONT_KNOW_WHERE_TO_START(4, "무엇부터 해야 할지 몰라서"),
+    PERFECTIONISM(8, "완벽하게 해내고 싶어서"),
+    CANT_CONCENTRATE(16, "집중이 안 돼서"),
+    NOT_FUN(32, "재미없거나 하기 싫어서");
+
+    private final int value;
+    private final String description;
+
+    public static boolean isSet(long mask, DelayReason reason) {
+        return (mask & reason.getValue()) != 0;
+    }
+
+    public static long addToMask(long mask, DelayReason reason) {
+        return mask | reason.getValue();
+    }
+
+    public static long removeFromMask(long mask, DelayReason reason) {
+        return mask & ~reason.getValue();
+    }
+
+    public static java.util.Set<DelayReason> fromMask(long mask) {
+        java.util.Set<DelayReason> reasons = new java.util.HashSet<>();
+        for (DelayReason reason : values()) {
+            if (isSet(mask, reason)) {
+                reasons.add(reason);
+            }
+        }
+        return reasons;
+    }
+
+    public static long createMask(java.util.Set<DelayReason> reasons) {
+        long mask = 0;
+        for (DelayReason reason : reasons) {
+            mask = addToMask(mask, reason);
+        }
+        return mask;
+    }
 }
+

--- a/src/main/java/com/miruni/backend/domain/user/entity/DelayReason.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/DelayReason.java
@@ -2,6 +2,9 @@ package com.miruni.backend.domain.user.entity;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -29,14 +32,10 @@ public enum DelayReason {
         return mask & ~reason.getValue();
     }
 
-    public static java.util.Set<DelayReason> fromMask(long mask) {
-        java.util.Set<DelayReason> reasons = new java.util.HashSet<>();
-        for (DelayReason reason : values()) {
-            if (isSet(mask, reason)) {
-                reasons.add(reason);
-            }
-        }
-        return reasons;
+    public static Set<DelayReason> fromMask(long mask) {
+        return Arrays.stream(values())
+            .filter(reason -> isSet(mask, reason))
+            .collect(Collectors.toSet());
     }
 
     public static long createMask(java.util.Set<DelayReason> reasons) {

--- a/src/main/java/com/miruni/backend/domain/user/entity/DelaySituation.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/DelaySituation.java
@@ -1,6 +1,49 @@
 package com.miruni.backend.domain.user.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum DelaySituation {
-    Phone
+
+    PHONE(1, "휴대폰을 사용할 때 (SNS, 게임 등)"),
+    VIDEO(2, "넷플릭스, 드라마, 유튜브 등 영상 시청"),
+    MEET_FRIENDS(4, "친구, 사람들을 만날 때"),
+    TOO_MUCH_WORK(8, "다른 일이 너무 많을 때"),
+    TOO_TIRED(16, "너무 피곤할 때");
+
+    private final int value;
+    private final String description;
+
+    public static boolean isSet(long mask, DelaySituation situation) {
+        return (mask & situation.getValue()) != 0;
+    }
+
+    public static long addToMask(long mask, DelaySituation situation) {
+        return mask | situation.getValue();
+    }
+
+    public static long removeFromMask(long mask, DelaySituation situation) {
+        return mask & ~situation.getValue();
+    }
+
+    public static java.util.Set<DelaySituation> fromMask(long mask) {
+        java.util.Set<DelaySituation> situations = new java.util.HashSet<>();
+        for (DelaySituation situation : values()) {
+            if (isSet(mask, situation)) {
+                situations.add(situation);
+            }
+        }
+        return situations;
+    }
+
+    public static long createMask(java.util.Set<DelaySituation> situations) {
+        long mask = 0;
+        for (DelaySituation situation : situations) {
+            mask = addToMask(mask, situation);
+        }
+        return mask;
+    }
 }
 

--- a/src/main/java/com/miruni/backend/domain/user/entity/DelaySituation.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/DelaySituation.java
@@ -2,6 +2,9 @@ package com.miruni.backend.domain.user.entity;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -28,17 +31,13 @@ public enum DelaySituation {
         return mask & ~situation.getValue();
     }
 
-    public static java.util.Set<DelaySituation> fromMask(long mask) {
-        java.util.Set<DelaySituation> situations = new java.util.HashSet<>();
-        for (DelaySituation situation : values()) {
-            if (isSet(mask, situation)) {
-                situations.add(situation);
-            }
-        }
-        return situations;
+    public static Set<DelaySituation> fromMask(long mask) {
+        return Arrays.stream(values())
+            .filter(situation -> isSet(mask, situation))
+            .collect(Collectors.toSet());
     }
 
-    public static long createMask(java.util.Set<DelaySituation> situations) {
+    public static long createMask(Set<DelaySituation> situations) {
         long mask = 0;
         for (DelaySituation situation : situations) {
             mask = addToMask(mask, situation);

--- a/src/main/java/com/miruni/backend/domain/user/entity/Survey.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/Survey.java
@@ -2,14 +2,14 @@ package com.miruni.backend.domain.user.entity;
 
 import com.miruni.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.*;
+
+import java.util.Set;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "survey")
 public class Survey extends BaseEntity {
@@ -19,23 +19,41 @@ public class Survey extends BaseEntity {
     @Column(name = "survey_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
-    // 어떤 상황에 미루나요 (복수 선택 가능)
+    // 어떤 상황에 미루나요 (복수 선택 가능) - 비트마스크
+    @Column(name = "delay_situation_mask", nullable = false)
+    private long delaySituationMask;
+
+    // 미루는 정도 (단일 선택)
     @Enumerated(EnumType.STRING)
-    @Column(name = "delay_situation", nullable = false)
-    private DelaySituation delaySituation;
+    @Column(name = "delay_level", nullable = false, length = 20)
+    private DelayLevel delayLevel;
 
-    // 미루는 정도 (1~5)
-    @Column(name = "delay_range", nullable = false)
-    @Min(1) @Max(5)
-    private int delayRange;
+    // 어떤 이유에 미루나요 (복수 선택 가능) - 비트마스크
+    @Column(name = "delay_reason_mask", nullable = false)
+    private long delayReasonMask;
 
-    // 어떤 이유에 미루나요 (복수 선택 가능)
-    @Enumerated(EnumType.STRING)
-    @Column(name = "delay_reason", nullable = false)
-    private DelayReason delayReason;
+    // === 정적 팩토리 ===
+    public static Survey create(User user, Set<DelaySituation> situations, DelayLevel level, Set<DelayReason> reasons) {
+        long situationMask = DelaySituation.createMask(situations);
+        long reasonMask = DelayReason.createMask(reasons);
 
+        return Survey.builder()
+                .user(user)
+                .delaySituationMask(situationMask)
+                .delayLevel(level)
+                .delayReasonMask(reasonMask)
+                .build();
+    }
+
+    // === 수정 로직 ===
+    public void update(Set<DelaySituation> situations, DelayLevel level, Set<DelayReason> reasons) {
+        this.delaySituationMask = DelaySituation.createMask(situations);
+        this.delayLevel = level;
+        this.delayReasonMask = DelayReason.createMask(reasons);
+    }
 }
+

--- a/src/main/java/com/miruni/backend/domain/user/entity/Survey.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/Survey.java
@@ -19,7 +19,7 @@ public class Survey extends BaseEntity {
     @Column(name = "survey_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 

--- a/src/main/java/com/miruni/backend/domain/user/entity/User.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/User.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "user")
 public class User extends BaseEntity {
@@ -47,6 +47,11 @@ public class User extends BaseEntity {
     private int peanutCount = 0;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    @Builder.Default
+    private UserRole role = UserRole.USER;
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "oauth_provider")
     private OauthProvider oauthProvider;
 
@@ -72,7 +77,46 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FcmToken> fcmTokens = new ArrayList<>();
 
+    // ===== 비즈니스 로직 =====
+
     public void addPeanuts(int count) {
         this.peanutCount += count;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void changeRole(UserRole role) {
+        this.role = role;
+    }
+
+    // ===== 정적 팩토리 메서드 =====
+
+    /**
+     * 일반 회원가입용 USER 생성
+     */
+    public static User createNormalUser(String email, String encodedPassword, String nickname) {
+        return User.builder()
+                .email(email)
+                .password(encodedPassword)
+                .nickname(nickname)
+                .peanutCount(0)
+                .role(UserRole.USER)
+                .build();
+    }
+
+    /**
+     * 소셜 로그인 신규 유저 (ROLE_GUEST)
+     */
+    public static User createSocialGuest(String name, String email, String encodedPassword, String nickname, OauthProvider provider) {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .password(encodedPassword)
+                .nickname(nickname)
+                .oauthProvider(provider)
+                .role(UserRole.GUEST)
+                .build();
     }
 }

--- a/src/main/java/com/miruni/backend/domain/user/entity/User.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/User.java
@@ -62,8 +62,8 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user")
     private List<Agreement> agreements = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
-    private List<Survey> surveys = new ArrayList<>();
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Survey survey;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Plan> plans = new ArrayList<>();
@@ -89,6 +89,10 @@ public class User extends BaseEntity {
 
     public void changeRole(UserRole role) {
         this.role = role;
+    }
+
+    public Survey getSurvey() {
+        return this.survey;
     }
 
     // ===== 정적 팩토리 메서드 =====

--- a/src/main/java/com/miruni/backend/domain/user/entity/User.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/User.java
@@ -60,21 +60,23 @@ public class User extends BaseEntity {
     private ProfileImage profileImage;
 
     @OneToMany(mappedBy = "user")
+    @Builder.Default
     private List<Agreement> agreements = new ArrayList<>();
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Survey survey;
-
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<Plan> plans = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<BasicPlan> basicPlans = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
+    @Builder.Default
     private List<Question> questions = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<FcmToken> fcmTokens = new ArrayList<>();
 
     // ===== 비즈니스 로직 =====
@@ -89,10 +91,6 @@ public class User extends BaseEntity {
 
     public void changeRole(UserRole role) {
         this.role = role;
-    }
-
-    public Survey getSurvey() {
-        return this.survey;
     }
 
     // ===== 정적 팩토리 메서드 =====
@@ -111,7 +109,7 @@ public class User extends BaseEntity {
     }
 
     /**
-     * 소셜 로그인 신규 유저 (ROLE_GUEST)
+     * 소셜 로그인 신규 유저 (가입 미완료: ROLE_GUEST)
      */
     public static User createSocialGuest(String name, String email, String encodedPassword, String nickname, OauthProvider provider) {
         return User.builder()
@@ -120,7 +118,7 @@ public class User extends BaseEntity {
                 .password(encodedPassword)
                 .nickname(nickname)
                 .oauthProvider(provider)
-                .role(UserRole.GUEST)
+                .role(UserRole.PENDING_SIGNUP)
                 .build();
     }
 }

--- a/src/main/java/com/miruni/backend/domain/user/entity/UserRole.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/UserRole.java
@@ -7,7 +7,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserRole {
 
-    GUEST("ROLE_GUEST"),
+    /**
+     * 소셜 로그인은 완료됐지만 약관/닉네임 등 최종 가입이 완료되지 않은 상태를 의미.
+     * 인가 관점에서는 ROLE_GUEST로 동작한다.
+     * */
+    PENDING_SIGNUP("ROLE_GUEST"),
     USER("ROLE_USER");
 
     private final String roleName;

--- a/src/main/java/com/miruni/backend/domain/user/entity/UserRole.java
+++ b/src/main/java/com/miruni/backend/domain/user/entity/UserRole.java
@@ -1,0 +1,16 @@
+package com.miruni.backend.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+    GUEST("ROLE_GUEST"),
+    USER("ROLE_USER");
+
+    private final String roleName;
+}
+
+

--- a/src/main/java/com/miruni/backend/domain/user/exception/ServeyErrorCode.java
+++ b/src/main/java/com/miruni/backend/domain/user/exception/ServeyErrorCode.java
@@ -1,0 +1,18 @@
+package com.miruni.backend.domain.user.exception;
+
+import com.miruni.backend.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ServeyErrorCode implements ErrorCode {
+
+    SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY404_1", "설문조사를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}
+

--- a/src/main/java/com/miruni/backend/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/miruni/backend/domain/user/exception/UserErrorCode.java
@@ -15,7 +15,9 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER400_4", "비밀번호가 올바르지 않습니다."),
     AGREEMENT_REQUIRED(HttpStatus.BAD_REQUEST, "USER400_5", "필수 약관에 동의해야 합니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "USER401_6", "유효하지 않은 토큰입니다."),
-    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER400_7", "이미 탈퇴한 사용자입니다.");
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER400_7", "이미 탈퇴한 사용자입니다."),
+    INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "USER401_8", "유효하지 않은 소셜 로그인 토큰입니다."),
+    OAUTH_PROVIDER_MISMATCH(HttpStatus.BAD_REQUEST, "USER400_9", "소셜 로그인 제공자 정보가 일치하지 않습니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/com/miruni/backend/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/miruni/backend/domain/user/exception/UserErrorCode.java
@@ -15,6 +15,11 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER400_4", "비밀번호가 올바르지 않습니다."),
     AGREEMENT_REQUIRED(HttpStatus.BAD_REQUEST, "USER400_5", "필수 약관에 동의해야 합니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "USER401_6", "유효하지 않은 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "USER401_9", "유효하지 않은 리프레시 토큰입니다."),
+    BLACKLISTED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "USER401_10", "사용이 중지된 리프레시 토큰입니다."),
+    REFRESH_TOKEN_USER_MISMATCH(HttpStatus.UNAUTHORIZED, "USER401_11", "리프레시 토큰의 사용자 정보가 일치하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER401_12", "저장된 리프레시 토큰이 없습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "USER401_13", "리프레시 토큰 정보가 서버와 일치하지 않습니다."),
     USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER400_7", "이미 탈퇴한 사용자입니다."),
     INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "USER401_8", "유효하지 않은 소셜 로그인 토큰입니다."),
     OAUTH_PROVIDER_MISMATCH(HttpStatus.BAD_REQUEST, "USER400_9", "소셜 로그인 제공자 정보가 일치하지 않습니다.");

--- a/src/main/java/com/miruni/backend/domain/user/repository/AgreementRepository.java
+++ b/src/main/java/com/miruni/backend/domain/user/repository/AgreementRepository.java
@@ -1,12 +1,11 @@
 package com.miruni.backend.domain.user.repository;
 
 import com.miruni.backend.domain.user.entity.Agreement;
-import com.miruni.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AgreementRepository extends JpaRepository<Agreement, Long> {
-    boolean existsByUser(User user);
+    boolean existsByUserId(Long userId);
 }
 

--- a/src/main/java/com/miruni/backend/domain/user/repository/AgreementRepository.java
+++ b/src/main/java/com/miruni/backend/domain/user/repository/AgreementRepository.java
@@ -1,10 +1,12 @@
 package com.miruni.backend.domain.user.repository;
 
 import com.miruni.backend.domain.user.entity.Agreement;
+import com.miruni.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AgreementRepository extends JpaRepository<Agreement, Long> {
+    boolean existsByUser(User user);
 }
 

--- a/src/main/java/com/miruni/backend/domain/user/repository/SurveyRepository.java
+++ b/src/main/java/com/miruni/backend/domain/user/repository/SurveyRepository.java
@@ -1,0 +1,14 @@
+package com.miruni.backend.domain.user.repository;
+
+import com.miruni.backend.domain.user.entity.Survey;
+import com.miruni.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+
+    Survey findByUser(User user);
+}
+
+
+
+

--- a/src/main/java/com/miruni/backend/domain/user/repository/SurveyRepository.java
+++ b/src/main/java/com/miruni/backend/domain/user/repository/SurveyRepository.java
@@ -1,12 +1,11 @@
 package com.miruni.backend.domain.user.repository;
 
 import com.miruni.backend.domain.user.entity.Survey;
-import com.miruni.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
 
-    Survey findByUser(User user);
+    Survey findByUserId(Long userId);
 }
 
 

--- a/src/main/java/com/miruni/backend/domain/user/service/AuthCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/AuthCommandService.java
@@ -1,28 +1,48 @@
 package com.miruni.backend.domain.user.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.miruni.backend.domain.user.dto.AuthUserInfoDto;
+import com.miruni.backend.domain.user.dto.request.GoogleLoginRequest;
+import com.miruni.backend.domain.user.dto.request.KakaoLoginRequest;
 import com.miruni.backend.domain.user.dto.request.LoginRequest;
+import com.miruni.backend.domain.user.dto.request.SocialSignupCompleteRequest;
 import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
+import com.miruni.backend.domain.user.dto.response.SocialLoginResponseDto;
+import com.miruni.backend.domain.user.entity.Agreement;
+import com.miruni.backend.domain.user.entity.OauthProvider;
 import com.miruni.backend.domain.user.entity.User;
+import com.miruni.backend.domain.user.entity.UserRole;
 import com.miruni.backend.domain.user.exception.UserErrorCode;
+import com.miruni.backend.domain.user.repository.AgreementRepository;
 import com.miruni.backend.domain.user.repository.UserRepository;
+import com.miruni.backend.domain.user.validator.UserValidator;
 import com.miruni.backend.global.authroize.TokenService;
+import com.miruni.backend.global.common.JwtUtil;
 import com.miruni.backend.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+import java.util.UUID;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class AuthCommandService {
-    
+
     private final UserRepository userRepository;
+    private final AgreementRepository agreementRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenService tokenService;
-    
+    private final UserValidator userValidator;
+
     /**
      * 일반 로그인
      */
@@ -30,12 +50,12 @@ public class AuthCommandService {
         // 이메일로 사용자 조회
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
-        
+
         // 비밀번호 검증
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw BaseException.type(UserErrorCode.INVALID_PASSWORD);
         }
-        
+
         // 토큰 발급
         log.info("로그인 성공: email={}, userId={}", request.email(), user.getId());
         return tokenService.issueTokenResponse(user);
@@ -46,6 +66,210 @@ public class AuthCommandService {
      */
     public void logout(String accessToken, Long userId) {
         tokenService.logout(accessToken, userId);
+    }
+
+    /**
+     * 구글 소셜 로그인
+     */
+    public SocialLoginResponseDto loginWithGoogle(GoogleLoginRequest request) {
+        AuthUserInfoDto googleUserInfo = verifyGoogleIdToken(request.googleIdToken());
+        return processSocialLogin(googleUserInfo, OauthProvider.Google);
+    }
+
+    /**
+     * 카카오 소셜 로그인
+     */
+    public SocialLoginResponseDto loginWithKakao(KakaoLoginRequest request) {
+        AuthUserInfoDto kakaoUserInfo = verifyKakaoAccessToken(request.accessToken());
+        return processSocialLogin(kakaoUserInfo, OauthProvider.Kakao);
+    }
+
+    /**
+     * 소셜 로그인 공통 처리 로직 (ROLE_GUEST 기반)
+     */
+    private SocialLoginResponseDto processSocialLogin(AuthUserInfoDto userInfo, OauthProvider provider) {
+        Optional<User> optionalUser = userRepository.findByEmail(userInfo.email());
+        boolean isNewUser = optionalUser.isEmpty();
+
+        if (optionalUser.isPresent()) {
+            User user = optionalUser.get();
+
+            // 다른 소셜 제공자로 이미 가입된 이메일인 경우
+            if (user.getOauthProvider() != null && user.getOauthProvider() != provider) {
+                throw BaseException.type(UserErrorCode.OAUTH_PROVIDER_MISMATCH);
+            }
+
+            if (user.isDeleted()) {
+                user.restore();
+            }
+
+            boolean hasAgreements = agreementRepository.existsByUser(user);
+
+            // 약관까지 완료된 유저면 ROLE_USER 토큰으로 바로 로그인 처리
+            if (hasAgreements && user.getRole() == UserRole.USER) {
+                JwtResponseDto tokens = tokenService.issueTokenResponse(user);
+                return SocialLoginResponseDto.loggedIn(tokens, false);
+            }
+
+            // 약관 미완료 / ROLE_GUEST 인 경우 → ROLE_GUEST 토큰 발급 후 signupRequired = true
+            JwtResponseDto guestTokens = tokenService.issueTokenResponse(user);
+            return SocialLoginResponseDto.signupNeeded(guestTokens, false);
+        }
+
+        // 신규 소셜 유저 생성 (ROLE_GUEST, 임시 닉네임/비밀번호)
+        User newUser = createPendingSocialUser(userInfo, provider);
+        userRepository.save(newUser);
+
+        JwtResponseDto guestTokens = tokenService.issueTokenResponse(newUser);
+        return SocialLoginResponseDto.signupNeeded(guestTokens, isNewUser);
+    }
+
+    private User createPendingSocialUser(AuthUserInfoDto userInfo, OauthProvider provider) {
+        String randomPassword = UUID.randomUUID().toString();
+        String encodedPassword = passwordEncoder.encode(randomPassword);
+        String tempNickname = generateTempNickname(provider);
+
+        return User.createSocialGuest(
+                userInfo.name(),
+                userInfo.email(),
+                encodedPassword,
+                tempNickname,
+                provider
+        );
+    }
+
+    private String generateTempNickname(OauthProvider provider) {
+        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        return provider.name().toLowerCase() + "_" + suffix;
+    }
+
+    /**
+     * 소셜 회원가입 완료 (ROLE_GUEST → ROLE_USER 승격)
+     */
+    public JwtResponseDto completeSocialSignup(
+            OauthProvider provider,
+            Long userId,
+            SocialSignupCompleteRequest request
+    ) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
+
+        // 소셜 제공자 일치 여부 확인
+        if (user.getOauthProvider() != null && user.getOauthProvider() != provider) {
+            throw BaseException.type(UserErrorCode.OAUTH_PROVIDER_MISMATCH);
+        }
+
+        // 이미 약관/회원가입이 완료된 경우 -> 바로 토큰 재발급
+        if (agreementRepository.existsByUser(user) && user.getRole() == UserRole.USER) {
+            return tokenService.issueTokenResponse(user);
+        }
+
+        // 약관 검증
+        userValidator.validateAgreements(request.serviceAgreed(), request.privacyAgreed());
+
+        // 닉네임 중복 체크
+        if (userRepository.existsByNickname(request.nickname())) {
+            throw BaseException.type(UserErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+
+        // 프로필/약관 업데이트 및 ROLE_USER 승격
+        user.updateNickname(request.nickname());
+        user.changeRole(UserRole.USER);
+
+        Agreement agreement = Agreement.create(
+                user,
+                request.serviceAgreed(),
+                request.privacyAgreed(),
+                request.marketingAgreed()
+        );
+        agreementRepository.save(agreement);
+
+        // 최종 JWT 토큰 발급 (ROLE_USER)
+        return tokenService.issueTokenResponse(user);
+    }
+
+    /**
+     * Google ID Token 검증 및 사용자 정보 파싱
+     */
+    private AuthUserInfoDto verifyGoogleIdToken(String idToken) {
+        try {
+            String url = "https://oauth2.googleapis.com/tokeninfo?id_token=" + idToken;
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+            if (response.getStatusCode() != HttpStatus.OK) {
+                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode node = objectMapper.readTree(response.getBody());
+
+            String email = node.get("email").asText();
+            String name = node.has("name") ? node.get("name").asText() : "";
+
+            return AuthUserInfoDto.of(email, name);
+
+        } catch (Exception e) {
+            log.warn("Google ID 토큰 검증 실패: {}", e.getMessage());
+            throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+    }
+
+    /**
+     * Kakao Access Token 검증 및 사용자 정보 파싱
+     */
+    private AuthUserInfoDto verifyKakaoAccessToken(String accessToken) {
+        try {
+            String url = "https://kapi.kakao.com/v2/user/me";
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(accessToken);
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    String.class
+            );
+
+            if (response.getStatusCode() != HttpStatus.OK) {
+                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode node = objectMapper.readTree(response.getBody());
+
+            JsonNode accountNode = node.get("kakao_account");
+            if (accountNode == null) {
+                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
+            String email = accountNode.has("email") && !accountNode.get("email").isNull()
+                    ? accountNode.get("email").asText()
+                    : null;
+
+            if (email == null) {
+                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
+            String name = "";
+            if (accountNode.has("profile") && !accountNode.get("profile").isNull()) {
+                JsonNode profileNode = accountNode.get("profile");
+                if (profileNode.has("nickname") && !profileNode.get("nickname").isNull()) {
+                    name = profileNode.get("nickname").asText();
+                }
+            }
+
+            return AuthUserInfoDto.of(email, name);
+
+        } catch (Exception e) {
+            log.warn("Kakao Access Token 검증 실패: {}", e.getMessage());
+            throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+        }
     }
 }
 

--- a/src/main/java/com/miruni/backend/domain/user/service/AuthCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/AuthCommandService.java
@@ -1,7 +1,5 @@
 package com.miruni.backend.domain.user.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.miruni.backend.domain.user.dto.AuthUserInfoDto;
 import com.miruni.backend.domain.user.dto.request.GoogleLoginRequest;
 import com.miruni.backend.domain.user.dto.request.KakaoLoginRequest;
@@ -18,14 +16,14 @@ import com.miruni.backend.domain.user.repository.AgreementRepository;
 import com.miruni.backend.domain.user.repository.UserRepository;
 import com.miruni.backend.domain.user.validator.UserValidator;
 import com.miruni.backend.global.authroize.TokenService;
+import com.miruni.backend.global.client.GoogleAuthClient;
+import com.miruni.backend.global.client.KakaoAuthClient;
 import com.miruni.backend.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -41,6 +39,8 @@ public class AuthCommandService {
     private final PasswordEncoder passwordEncoder;
     private final TokenService tokenService;
     private final UserValidator userValidator;
+    private final GoogleAuthClient googleAuthClient;
+    private final KakaoAuthClient kakaoAuthClient;
 
     /**
      * 일반 로그인
@@ -81,7 +81,7 @@ public class AuthCommandService {
      * 구글 소셜 로그인
      */
     public SocialLoginResponseDto loginWithGoogle(GoogleLoginRequest request) {
-        AuthUserInfoDto googleUserInfo = verifyGoogleIdToken(request.googleIdToken());
+        AuthUserInfoDto googleUserInfo = googleAuthClient.getUserInfoByIdToken(request.googleIdToken());
         return processSocialLogin(googleUserInfo, OauthProvider.Google);
     }
 
@@ -89,12 +89,12 @@ public class AuthCommandService {
      * 카카오 소셜 로그인
      */
     public SocialLoginResponseDto loginWithKakao(KakaoLoginRequest request) {
-        AuthUserInfoDto kakaoUserInfo = verifyKakaoAccessToken(request.accessToken());
+        AuthUserInfoDto kakaoUserInfo = kakaoAuthClient.getUserInfoByAccessToken(request.accessToken());
         return processSocialLogin(kakaoUserInfo, OauthProvider.Kakao);
     }
 
     /**
-     * 소셜 로그인 공통 처리 로직 (ROLE_GUEST 기반)
+     * 소셜 로그인 공통 처리 로직 (가입 미완료는 ROLE_GUEST(PENDING_SIGNUP)로 구분)
      */
     private SocialLoginResponseDto processSocialLogin(AuthUserInfoDto userInfo, OauthProvider provider) {
         Optional<User> optionalUser = userRepository.findByEmail(userInfo.email());
@@ -112,7 +112,7 @@ public class AuthCommandService {
                 user.restore();
             }
 
-            boolean hasAgreements = agreementRepository.existsByUser(user);
+            boolean hasAgreements = agreementRepository.existsByUserId(user.getId());
 
             // 약관까지 완료된 유저면 ROLE_USER 토큰으로 바로 로그인 처리
             if (hasAgreements && user.getRole() == UserRole.USER) {
@@ -120,12 +120,12 @@ public class AuthCommandService {
                 return SocialLoginResponseDto.loggedIn(tokens, false);
             }
 
-            // 약관 미완료 / ROLE_GUEST 인 경우 → ROLE_GUEST 토큰 발급 후 signupRequired = true
+            // 약관 미완료 / 가입 미완료(ROLE_GUEST)인 경우 → 토큰 발급 후 signupRequired = true
             JwtResponseDto guestTokens = tokenService.issueTokenResponse(user);
             return SocialLoginResponseDto.signupNeeded(guestTokens, false);
         }
 
-        // 신규 소셜 유저 생성 (ROLE_GUEST, 임시 닉네임/비밀번호)
+        // 신규 소셜 유저 생성 (ROLE_GUEST(PENDING_SIGNUP), 임시 닉네임/비밀번호)
         User newUser = createPendingSocialUser(userInfo, provider);
         userRepository.save(newUser);
 
@@ -153,7 +153,7 @@ public class AuthCommandService {
     }
 
     /**
-     * 소셜 회원가입 완료 (ROLE_GUEST → ROLE_USER 승격)
+     * 소셜 회원가입 완료 (ROLE_GUEST(PENDING_SIGNUP) → ROLE_USER)
      */
     public JwtResponseDto completeSocialSignup(
             OauthProvider provider,
@@ -169,7 +169,7 @@ public class AuthCommandService {
         }
 
         // 이미 약관/회원가입이 완료된 경우 -> 바로 토큰 재발급
-        if (agreementRepository.existsByUser(user) && user.getRole() == UserRole.USER) {
+        if (agreementRepository.existsByUserId(user.getId()) && user.getRole() == UserRole.USER) {
             return tokenService.issueTokenResponse(user);
         }
 
@@ -181,7 +181,7 @@ public class AuthCommandService {
             throw BaseException.type(UserErrorCode.NICKNAME_ALREADY_EXISTS);
         }
 
-        // 프로필/약관 업데이트 및 ROLE_USER 승격
+        // 프로필/약관 업데이트 및 ROLE_USER 전환
         user.updateNickname(request.nickname());
         user.changeRole(UserRole.USER);
 
@@ -197,88 +197,5 @@ public class AuthCommandService {
         return tokenService.issueTokenResponse(user);
     }
 
-    /**
-     * Google ID Token 검증 및 사용자 정보 파싱
-     */
-    private AuthUserInfoDto verifyGoogleIdToken(String idToken) {
-        try {
-            String url = "https://oauth2.googleapis.com/tokeninfo?id_token=" + idToken;
-            RestTemplate restTemplate = new RestTemplate();
-            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
-
-            if (response.getStatusCode() != HttpStatus.OK) {
-                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
-            }
-
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode node = objectMapper.readTree(response.getBody());
-
-            String email = node.get("email").asText();
-            String name = node.has("name") ? node.get("name").asText() : "";
-
-            return AuthUserInfoDto.of(email, name);
-
-        } catch (Exception e) {
-            log.warn("Google ID 토큰 검증 실패: {}", e.getMessage());
-            throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
-        }
-    }
-
-    /**
-     * Kakao Access Token 검증 및 사용자 정보 파싱
-     */
-    private AuthUserInfoDto verifyKakaoAccessToken(String accessToken) {
-        try {
-            String url = "https://kapi.kakao.com/v2/user/me";
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.setBearerAuth(accessToken);
-            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-            HttpEntity<Void> entity = new HttpEntity<>(headers);
-
-            RestTemplate restTemplate = new RestTemplate();
-            ResponseEntity<String> response = restTemplate.exchange(
-                    url,
-                    HttpMethod.GET,
-                    entity,
-                    String.class
-            );
-
-            if (response.getStatusCode() != HttpStatus.OK) {
-                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
-            }
-
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode node = objectMapper.readTree(response.getBody());
-
-            JsonNode accountNode = node.get("kakao_account");
-            if (accountNode == null) {
-                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
-            }
-
-            String email = accountNode.has("email") && !accountNode.get("email").isNull()
-                    ? accountNode.get("email").asText()
-                    : null;
-
-            if (email == null) {
-                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
-            }
-
-            String name = "";
-            if (accountNode.has("profile") && !accountNode.get("profile").isNull()) {
-                JsonNode profileNode = accountNode.get("profile");
-                if (profileNode.has("nickname") && !profileNode.get("nickname").isNull()) {
-                    name = profileNode.get("nickname").asText();
-                }
-            }
-
-            return AuthUserInfoDto.of(email, name);
-
-        } catch (Exception e) {
-            log.warn("Kakao Access Token 검증 실패: {}", e.getMessage());
-            throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
-        }
-    }
 }
 

--- a/src/main/java/com/miruni/backend/domain/user/service/AuthCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/AuthCommandService.java
@@ -18,7 +18,6 @@ import com.miruni.backend.domain.user.repository.AgreementRepository;
 import com.miruni.backend.domain.user.repository.UserRepository;
 import com.miruni.backend.domain.user.validator.UserValidator;
 import com.miruni.backend.global.authroize.TokenService;
-import com.miruni.backend.global.common.JwtUtil;
 import com.miruni.backend.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -66,6 +65,16 @@ public class AuthCommandService {
      */
     public void logout(String accessToken, Long userId) {
         tokenService.logout(accessToken, userId);
+    }
+
+    /**
+     * 액세스/리프레시 토큰 재발급
+     */
+    public JwtResponseDto reissueToken(Long userId, String refreshToken) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
+
+        return tokenService.reissueToken(user, refreshToken);
     }
 
     /**

--- a/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
@@ -113,7 +113,7 @@ public class UserCommandService {
                 .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
 
         // 기존 설문이 있으면 수정, 없으면 새로 생성
-        Survey survey = user.getSurvey();
+        Survey survey = surveyRepository.findByUserId(userId);
 
         if (survey == null) {
             survey = Survey.create(

--- a/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
@@ -45,8 +45,8 @@ public class UserCommandService {
         // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(request.password());
         
-        // User 엔티티 생성 및 저장
-        User user = request.toEntity(encodedPassword);
+        // User 엔티티 생성 및 저장 
+        User user = User.createNormalUser(request.email(), encodedPassword, request.nickname());
         userRepository.save(user);
         
         // Agreement 엔티티 생성 및 저장

--- a/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/UserCommandService.java
@@ -1,11 +1,15 @@
 package com.miruni.backend.domain.user.service;
 
+import com.miruni.backend.domain.user.dto.request.SurveyRequest;
 import com.miruni.backend.domain.user.dto.request.UserSignupRequest;
 import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
+import com.miruni.backend.domain.user.dto.response.SurveyResponse;
 import com.miruni.backend.domain.user.entity.Agreement;
+import com.miruni.backend.domain.user.entity.Survey;
 import com.miruni.backend.domain.user.entity.User;
 import com.miruni.backend.domain.user.exception.UserErrorCode;
 import com.miruni.backend.domain.user.repository.AgreementRepository;
+import com.miruni.backend.domain.user.repository.SurveyRepository;
 import com.miruni.backend.domain.user.repository.UserRepository;
 import com.miruni.backend.domain.user.validator.UserValidator;
 import com.miruni.backend.global.authroize.TokenService;
@@ -13,6 +17,9 @@ import com.miruni.backend.global.exception.BaseException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +35,7 @@ public class UserCommandService {
     private final PasswordEncoder passwordEncoder;
     private final UserValidator userValidator;
     private final TokenService tokenService;
+    private final SurveyRepository surveyRepository;
     
     /**
      * 일반 회원가입
@@ -95,5 +103,42 @@ public class UserCommandService {
         tokenService.logout(accessToken, userId);
 
         log.info("회원 탈퇴 완료: userId={}", userId);
+    }
+
+    /**
+     * 설문조사 수정/저장
+     */
+    public SurveyResponse updateSurvey(SurveyRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
+
+        // 기존 설문이 있으면 수정, 없으면 새로 생성
+        Survey survey = user.getSurvey();
+
+        if (survey == null) {
+            survey = Survey.create(
+                    user,
+                    request.situations(),
+                    request.level(),
+                    request.reasons()
+            );
+            surveyRepository.save(survey);
+        } else {
+            // 기존 설문 업데이트 (JPA 더티 체킹)
+            survey.update(
+                    request.situations(),
+                    request.level(),
+                    request.reasons()
+            );
+        }
+
+        log.info("설문조사 수정: userId={}, situations={}, level={}, reasons={}",
+                userId, request.situations(), request.level(), request.reasons());
+
+        return SurveyResponse.of(
+                "설문조사가 수정되었습니다!",
+                LocalDateTime.now(),
+                "UPDATED"
+        );
     }
 }

--- a/src/main/java/com/miruni/backend/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/UserQueryService.java
@@ -1,9 +1,11 @@
 package com.miruni.backend.domain.user.service;
 
 import com.miruni.backend.domain.user.dto.response.UserSurveyResponse;
+import com.miruni.backend.domain.user.entity.Survey;
 import com.miruni.backend.domain.user.entity.User;
 import com.miruni.backend.domain.user.exception.ServeyErrorCode;
 import com.miruni.backend.domain.user.exception.UserErrorCode;
+import com.miruni.backend.domain.user.repository.SurveyRepository;
 import com.miruni.backend.domain.user.repository.UserRepository;
 import com.miruni.backend.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class UserQueryService {
 
     private final UserRepository userRepository;
+    private final SurveyRepository surveyRepository;
 
     public User getUserById(Long id){
         return userRepository.findById(id)
@@ -21,14 +24,16 @@ public class UserQueryService {
     }
 
     public UserSurveyResponse getUserSurveyResult(Long userId) {
-        User user = userRepository.findById(userId)
+        // 사용자 존재 검증 (Survey만 조회하면 USER_NOT_FOUND 대신 SURVEY_NOT_FOUND가 나갈 수 있어 분리)
+        userRepository.findById(userId)
                 .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
 
-        if (user.getSurvey() == null) {
+        Survey survey = surveyRepository.findByUserId(userId);
+        if (survey == null) {
             throw BaseException.type(ServeyErrorCode.SURVEY_NOT_FOUND);
         }
 
-        return UserSurveyResponse.fromSurvey(user.getSurvey());
+        return UserSurveyResponse.fromSurvey(survey);
     }
 }
 

--- a/src/main/java/com/miruni/backend/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/user/service/UserQueryService.java
@@ -1,6 +1,8 @@
 package com.miruni.backend.domain.user.service;
 
+import com.miruni.backend.domain.user.dto.response.UserSurveyResponse;
 import com.miruni.backend.domain.user.entity.User;
+import com.miruni.backend.domain.user.exception.ServeyErrorCode;
 import com.miruni.backend.domain.user.exception.UserErrorCode;
 import com.miruni.backend.domain.user.repository.UserRepository;
 import com.miruni.backend.global.exception.BaseException;
@@ -17,4 +19,17 @@ public class UserQueryService {
         return userRepository.findById(id)
                 .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
     }
+
+    public UserSurveyResponse getUserSurveyResult(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.getSurvey() == null) {
+            throw BaseException.type(ServeyErrorCode.SURVEY_NOT_FOUND);
+        }
+
+        return UserSurveyResponse.fromSurvey(user.getSurvey());
+    }
 }
+
+

--- a/src/main/java/com/miruni/backend/domain/user/validator/UserValidator.java
+++ b/src/main/java/com/miruni/backend/domain/user/validator/UserValidator.java
@@ -14,8 +14,15 @@ public class UserValidator {
      * 약관 동의 검증
      */
     public void validateAgreements(UserSignupRequest request) {
+        validateAgreements(request.serviceAgreed(), request.privacyAgreed());
+    }
+
+    /**
+     * 약관 동의 검증 (필드 기반)
+     */
+    public void validateAgreements(Boolean serviceAgreed, Boolean privacyAgreed) {
         // 서비스 이용약관은 필수
-        if (request.serviceAgreed() == null || !request.serviceAgreed()) {
+        if (serviceAgreed == null || !serviceAgreed) {
             throw BaseException.type(UserErrorCode.AGREEMENT_REQUIRED);
         }
     }

--- a/src/main/java/com/miruni/backend/global/authroize/CustomUserDetails.java
+++ b/src/main/java/com/miruni/backend/global/authroize/CustomUserDetails.java
@@ -22,8 +22,8 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        // 기본 권한 부여 (추후 Role 추가 시 수정)
-        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+        String roleName = user.getRole() != null ? user.getRole().getRoleName() : "ROLE_USER";
+        return Collections.singletonList(new SimpleGrantedAuthority(roleName));
     }
 
     @Override

--- a/src/main/java/com/miruni/backend/global/authroize/TokenService.java
+++ b/src/main/java/com/miruni/backend/global/authroize/TokenService.java
@@ -2,8 +2,10 @@ package com.miruni.backend.global.authroize;
 
 import com.miruni.backend.domain.user.dto.response.JwtResponseDto;
 import com.miruni.backend.domain.user.entity.User;
+import com.miruni.backend.domain.user.exception.UserErrorCode;
 import com.miruni.backend.global.common.JwtUtil;
 import com.miruni.backend.global.common.TokenDto;
+import com.miruni.backend.global.exception.BaseException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +48,57 @@ public class TokenService {
                 token.accessTokenExp(),
                 token.refreshTokenExp()
         );
+    }
+
+    /**
+     * 토큰 재발급 (Refresh Token Rotation)
+     */
+    public JwtResponseDto reissueToken(User user, String refreshToken) {
+        Long userId = user.getId();
+
+        try {
+            // 토큰 유효성 및 타입 검증
+            if (!jwtUtil.validateToken(refreshToken) || !jwtUtil.isRefreshToken(refreshToken)) {
+                throw BaseException.type(UserErrorCode.INVALID_TOKEN);
+            }
+
+            // 블랙리스트 여부 확인
+            if (isTokenBlacklisted(refreshToken)) {
+                throw BaseException.type(UserErrorCode.INVALID_TOKEN);
+            }
+
+            // 토큰에 담긴 사용자 정보와 현재 인증된 사용자 일치 여부 확인
+            Long tokenUserId = jwtUtil.getUserIdFromToken(refreshToken);
+            if (!userId.equals(tokenUserId)) {
+                throw BaseException.type(UserErrorCode.INVALID_TOKEN);
+            }
+
+            // Redis 에 저장된 리프레시 토큰 조회
+            String storedRefreshToken = getRefreshToken(userId.toString());
+            if (storedRefreshToken == null || !refreshToken.equals(storedRefreshToken)) {
+                throw BaseException.type(UserErrorCode.INVALID_TOKEN);
+            }
+
+            // 기존 리프레시 토큰 삭제 (Rotation)
+            deleteRefreshToken(userId.toString());
+
+            // 새 토큰 발급 및 저장
+            TokenDto token = createAndStoreTokens(user);
+
+            log.info("토큰 재발급 완료: userId={}", userId);
+
+            return JwtResponseDto.of(
+                    token.accessToken(),
+                    token.refreshToken(),
+                    token.accessTokenExp(),
+                    token.refreshTokenExp()
+            );
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("토큰 재발급 중 오류 발생: {}", e.getMessage());
+            throw BaseException.type(UserErrorCode.INVALID_TOKEN);
+        }
     }
 
     /**

--- a/src/main/java/com/miruni/backend/global/authroize/TokenService.java
+++ b/src/main/java/com/miruni/backend/global/authroize/TokenService.java
@@ -59,24 +59,27 @@ public class TokenService {
         try {
             // 토큰 유효성 및 타입 검증
             if (!jwtUtil.validateToken(refreshToken) || !jwtUtil.isRefreshToken(refreshToken)) {
-                throw BaseException.type(UserErrorCode.INVALID_TOKEN);
+                throw BaseException.type(UserErrorCode.INVALID_REFRESH_TOKEN);
             }
 
             // 블랙리스트 여부 확인
             if (isTokenBlacklisted(refreshToken)) {
-                throw BaseException.type(UserErrorCode.INVALID_TOKEN);
+                throw BaseException.type(UserErrorCode.BLACKLISTED_REFRESH_TOKEN);
             }
 
             // 토큰에 담긴 사용자 정보와 현재 인증된 사용자 일치 여부 확인
             Long tokenUserId = jwtUtil.getUserIdFromToken(refreshToken);
             if (!userId.equals(tokenUserId)) {
-                throw BaseException.type(UserErrorCode.INVALID_TOKEN);
+                throw BaseException.type(UserErrorCode.REFRESH_TOKEN_USER_MISMATCH);
             }
 
             // Redis 에 저장된 리프레시 토큰 조회
             String storedRefreshToken = getRefreshToken(userId.toString());
-            if (storedRefreshToken == null || !refreshToken.equals(storedRefreshToken)) {
-                throw BaseException.type(UserErrorCode.INVALID_TOKEN);
+            if (storedRefreshToken == null) {
+                throw BaseException.type(UserErrorCode.REFRESH_TOKEN_NOT_FOUND);
+            }
+            if (!refreshToken.equals(storedRefreshToken)) {
+                throw BaseException.type(UserErrorCode.REFRESH_TOKEN_MISMATCH);
             }
 
             // 기존 리프레시 토큰 삭제 (Rotation)
@@ -97,7 +100,7 @@ public class TokenService {
             throw e;
         } catch (Exception e) {
             log.error("토큰 재발급 중 오류 발생: {}", e.getMessage());
-            throw BaseException.type(UserErrorCode.INVALID_TOKEN);
+            throw BaseException.type(UserErrorCode.INVALID_REFRESH_TOKEN);
         }
     }
 

--- a/src/main/java/com/miruni/backend/global/client/GoogleAuthClient.java
+++ b/src/main/java/com/miruni/backend/global/client/GoogleAuthClient.java
@@ -1,0 +1,50 @@
+package com.miruni.backend.global.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.miruni.backend.domain.user.dto.AuthUserInfoDto;
+import com.miruni.backend.domain.user.exception.UserErrorCode;
+import com.miruni.backend.global.common.Constants;
+import com.miruni.backend.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Google OAuth 클라이언트
+ * - ID Token 검증 및 사용자 정보 파싱
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoogleAuthClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public AuthUserInfoDto getUserInfoByIdToken(String idToken) {
+        try {
+            String url = Constants.GOOGLE_TOKENINFO_URL + idToken;
+            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+
+            if (response.getStatusCode() != HttpStatus.OK) {
+                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
+            JsonNode node = objectMapper.readTree(response.getBody());
+
+            String email = node.get("email").asText();
+            String name = node.has("name") ? node.get("name").asText() : "";
+
+            return AuthUserInfoDto.of(email, name);
+
+        } catch (Exception e) {
+            log.warn("Google ID 토큰 검증 실패: {}", e.getMessage());
+            throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+    }
+}
+

--- a/src/main/java/com/miruni/backend/global/client/KakaoAuthClient.java
+++ b/src/main/java/com/miruni/backend/global/client/KakaoAuthClient.java
@@ -1,0 +1,80 @@
+package com.miruni.backend.global.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.miruni.backend.domain.user.dto.AuthUserInfoDto;
+import com.miruni.backend.domain.user.exception.UserErrorCode;
+import com.miruni.backend.global.common.Constants;
+import com.miruni.backend.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Kakao OAuth 클라이언트
+ * - Access Token 검증 및 사용자 정보 파싱
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoAuthClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public AuthUserInfoDto getUserInfoByAccessToken(String accessToken) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(accessToken);
+            headers.setContentType(org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED);
+
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    Constants.KAKAO_USERINFO_URL,
+                    HttpMethod.GET,
+                    entity,
+                    String.class
+            );
+
+            if (response.getStatusCode() != HttpStatus.OK) {
+                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
+            JsonNode node = objectMapper.readTree(response.getBody());
+            JsonNode accountNode = node.get("kakao_account");
+            if (accountNode == null) {
+                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
+            String email = accountNode.has("email") && !accountNode.get("email").isNull()
+                    ? accountNode.get("email").asText()
+                    : null;
+
+            if (email == null) {
+                throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
+            String name = "";
+            if (accountNode.has("profile") && !accountNode.get("profile").isNull()) {
+                JsonNode profileNode = accountNode.get("profile");
+                if (profileNode.has("nickname") && !profileNode.get("nickname").isNull()) {
+                    name = profileNode.get("nickname").asText();
+                }
+            }
+
+            return AuthUserInfoDto.of(email, name);
+
+        } catch (Exception e) {
+            log.warn("Kakao Access Token 검증 실패: {}", e.getMessage());
+            throw BaseException.type(UserErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+    }
+}
+

--- a/src/main/java/com/miruni/backend/global/common/BaseEntity.java
+++ b/src/main/java/com/miruni/backend/global/common/BaseEntity.java
@@ -35,4 +35,9 @@ public abstract class BaseEntity {
         this.deletedAt = LocalDateTime.now();
     }
 
+    // 소프트 삭제 복구
+    public void restore() {
+        this.deletedAt = null;
+    }
+
 }

--- a/src/main/java/com/miruni/backend/global/common/Constants.java
+++ b/src/main/java/com/miruni/backend/global/common/Constants.java
@@ -1,0 +1,15 @@
+package com.miruni.backend.global.common;
+
+/**
+ * 전역 상수 모음.
+ */
+public final class Constants {
+
+    private Constants() {
+    }
+
+    // --- OAuth 외부 API ---
+    public static final String GOOGLE_TOKENINFO_URL = "https://oauth2.googleapis.com/tokeninfo?id_token=";
+    public static final String KAKAO_USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
+}
+

--- a/src/main/java/com/miruni/backend/global/common/JwtUtil.java
+++ b/src/main/java/com/miruni/backend/global/common/JwtUtil.java
@@ -26,7 +26,6 @@ public class JwtUtil {
     private static final String CLAIM_TOKEN_TYPE = "type";
     private static final String TOKEN_TYPE_ACCESS = "ACCESS";
     private static final String TOKEN_TYPE_REFRESH = "REFRESH";
-    private static final String TOKEN_TYPE_TEMP = "TEMP";
 
     // ===== 공통 내부 로직 =====
 
@@ -59,11 +58,6 @@ public class JwtUtil {
     /** Refresh Token 생성 */
     public String generateRefreshToken(Long userId) {
         return generateToken(userId, TOKEN_TYPE_REFRESH, jwtProperties.refreshTokenExpiration());
-    }
-
-    /** 임시 토큰 생성 (이메일 인증 등에 사용) */
-    public String generateTempToken(Long userId) {
-        return generateToken(userId, TOKEN_TYPE_TEMP, jwtProperties.tempTokenExpiration());
     }
 
     /** Access + Refresh 한 번에 생성해서 DTO로 리턴 */
@@ -143,7 +137,7 @@ public class JwtUtil {
         }
     }
 
-    /** 토큰 타입(ACCESS/REFRESH/TEMP) 추출 */
+    /** 토큰 타입(ACCESS/REFRESH) 추출 */
     public String getTokenType(String token) {
         try {
             Claims claims = parseClaims(token);
@@ -160,10 +154,6 @@ public class JwtUtil {
 
     public boolean isRefreshToken(String token) {
         return TOKEN_TYPE_REFRESH.equals(getTokenType(token));
-    }
-
-    public boolean isTempToken(String token) {
-        return TOKEN_TYPE_TEMP.equals(getTokenType(token));
     }
 
     // ===== HTTP 요청에서 토큰 꺼내는 헬퍼 =====

--- a/src/main/java/com/miruni/backend/global/config/JwtFilter.java
+++ b/src/main/java/com/miruni/backend/global/config/JwtFilter.java
@@ -45,13 +45,7 @@ public class JwtFilter extends OncePerRequestFilter {
                     }
                     
                     Long userId = jwtUtil.getUserIdFromToken(token);
-                    
-                    // 임시 토큰인지 확인
-                    String tokenType = jwtUtil.getTokenType(token);
-                    if ("temp".equals(tokenType)) {
-                        log.debug("임시 토큰 사용: userId={}", userId);
-                    }
-                    
+
                     UserDetails userDetails = customUserDetailService.loadUserById(userId);
                     
                     UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/com/miruni/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/miruni/backend/global/config/SecurityConfig.java
@@ -45,8 +45,9 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/actuator/**",
-                                "/api/users", // 회원가입 API
-                                "/api/auth/token" // 로그인 API
+                                "/api/users",           // 일반 회원가입 API
+                                "/api/auth/token",      // 일반 로그인 API
+                                "/api/auth/social/**"   // 소셜 로그인/회원가입 완료 API
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,4 @@ jwt:
   access-token-expiration: 3600000
   refresh-token-expiration: 604800000
   temp-token-expiration: 300000
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,8 +39,9 @@ management:
 
 gemini:
   api:
-    key: {GEMINI_API_KEY}
+    key: ${GEMINI_API_KEY}
     url: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
+
 jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-expiration: 3600000


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #24 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 소셜로그인 관련 api 
- 엑세스 토큰 재발급 api
- 설문조사 관련 api

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
원래 계획했던 temp token 대신 GUEST 토큰/ROLE 방식으로 바꿨습니다.
나머지는 기존과 비슷하게 구현했습니다.
