### PR TITLE
[feat] 일반 일정 기간 설정 기능 추가 구현

### DIFF
--- a/src/main/java/com/miruni/backend/domain/fcm/service/NotificationService.java
+++ b/src/main/java/com/miruni/backend/domain/fcm/service/NotificationService.java
@@ -1,5 +1,6 @@
 package com.miruni.backend.domain.fcm.service;
 
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.miruni.backend.domain.plan.service.AiPlanQueryService;
 import com.miruni.backend.domain.plan.service.BasicPlanQueryService;
 import io.netty.util.concurrent.ScheduledFuture;

--- a/src/main/java/com/miruni/backend/domain/plan/controller/BasicPlanApi.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/BasicPlanApi.java
@@ -8,12 +8,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "Basic Plan API", description = "일반 일정 관련 API")
 public interface BasicPlanApi {
 
     @Operation(summary = "일반 일정 생성", description = "사용자가 새로운 일반 일정을 생성합니다.")
-    BasicPlanResponse createBasicPlan(@LoginUser Long userId,
-                                      @Valid @RequestBody BasicPlanSaveRequest request);
+    List<BasicPlanResponse> createBasicPlan(@LoginUser Long userId,
+                                            @Valid @RequestBody BasicPlanSaveRequest request);
 
     @Operation(summary = "일반 일정 수정", description = "일반 일정을 수정합니다.")
     BasicPlanResponse updateBasicPlan(@LoginUser Long userId,

--- a/src/main/java/com/miruni/backend/domain/plan/controller/BasicPlanApi.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/BasicPlanApi.java
@@ -1,6 +1,7 @@
 package com.miruni.backend.domain.plan.controller;
 
 import com.miruni.backend.domain.plan.dto.request.BasicPlanSaveRequest;
+import com.miruni.backend.domain.plan.dto.request.BasicPlanUpdateRequest;
 import com.miruni.backend.domain.plan.dto.response.BasicPlanResponse;
 import com.miruni.backend.global.authroize.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,7 +21,7 @@ public interface BasicPlanApi {
     @Operation(summary = "일반 일정 수정", description = "일반 일정을 수정합니다.")
     BasicPlanResponse updateBasicPlan(@LoginUser Long userId,
                                       @PathVariable Long basicPlanId,
-                                      @Valid @RequestBody BasicPlanSaveRequest request);
+                                      @Valid @RequestBody BasicPlanUpdateRequest request);
 
     @Operation(summary = "일반 일정 삭제", description = "일반 일정을 삭제합니다.")
     Long deleteBasicPlan(@LoginUser Long userId,

--- a/src/main/java/com/miruni/backend/domain/plan/controller/BasicPlanController.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/BasicPlanController.java
@@ -3,6 +3,7 @@ package com.miruni.backend.domain.plan.controller;
 import com.miruni.backend.domain.plan.dto.command.BasicPlanCreateCommand;
 import com.miruni.backend.domain.plan.dto.command.BasicPlanUpdateCommand;
 import com.miruni.backend.domain.plan.dto.request.BasicPlanSaveRequest;
+import com.miruni.backend.domain.plan.dto.request.BasicPlanUpdateRequest;
 import com.miruni.backend.domain.plan.dto.response.BasicPlanResponse;
 import com.miruni.backend.domain.plan.service.BasicPlanCommandService;
 import com.miruni.backend.global.authroize.LoginUser;
@@ -31,7 +32,7 @@ public class BasicPlanController implements BasicPlanApi{
     @PatchMapping("/{basicPlanId}")
     public BasicPlanResponse updateBasicPlan(@LoginUser Long userId,
                                              @PathVariable Long basicPlanId,
-                                             @Valid @RequestBody BasicPlanSaveRequest request) {
+                                             @Valid @RequestBody BasicPlanUpdateRequest request) {
         return basicPlanCommandService.updateBasicPlan(BasicPlanUpdateCommand.of(userId, basicPlanId, request));
     }
 

--- a/src/main/java/com/miruni/backend/domain/plan/controller/BasicPlanController.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/BasicPlanController.java
@@ -10,6 +10,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/plans")
 @RequiredArgsConstructor
@@ -19,8 +21,8 @@ public class BasicPlanController implements BasicPlanApi{
 
     @Override
     @PostMapping
-    public BasicPlanResponse createBasicPlan(@LoginUser Long userId,
-                                             @Valid @RequestBody BasicPlanSaveRequest request) {
+    public List<BasicPlanResponse> createBasicPlan(@LoginUser Long userId,
+                                                   @Valid @RequestBody BasicPlanSaveRequest request) {
 
         return basicPlanCommandService.createBasicPlan(BasicPlanCreateCommand.of(userId, request));
     }

--- a/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
@@ -79,8 +79,7 @@ public class PlanController implements PlanApi{
                 planType,
                 id,
                 userId,
-                request.expectedTime(),
-                request.actualTime()
+                request.expectedTime()
         );
 
         return planCommandService.finishPlan(command);

--- a/src/main/java/com/miruni/backend/domain/plan/dto/command/BasicPlanCreateCommand.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/command/BasicPlanCreateCommand.java
@@ -9,18 +9,23 @@ public record BasicPlanCreateCommand(
         Long userId,
         String title,
         String description,
-        LocalDate scheduledDate,
+        LocalDate startDate,
+        LocalDate endDate,     // nullable
         LocalTime startTime,
         LocalTime endTime,
         String priority
 ) {
 
-    public static BasicPlanCreateCommand of(Long userId, BasicPlanSaveRequest request) {
+    public static BasicPlanCreateCommand of(
+            Long userId,
+            BasicPlanSaveRequest request
+    ) {
         return new BasicPlanCreateCommand(
                 userId,
                 request.title(),
                 request.description(),
-                request.scheduledDate(),
+                request.startDate(),
+                request.endDate(),   // nullable
                 request.startTime(),
                 request.endTime(),
                 request.priority()

--- a/src/main/java/com/miruni/backend/domain/plan/dto/command/BasicPlanUpdateCommand.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/command/BasicPlanUpdateCommand.java
@@ -1,7 +1,7 @@
 package com.miruni.backend.domain.plan.dto.command;
 
 
-import com.miruni.backend.domain.plan.dto.request.BasicPlanSaveRequest;
+import com.miruni.backend.domain.plan.dto.request.BasicPlanUpdateRequest;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -21,26 +21,23 @@ public record BasicPlanUpdateCommand(
     public static BasicPlanUpdateCommand of(
             Long userId,
             Long planId,
-            BasicPlanSaveRequest request
+            BasicPlanUpdateRequest request
     ) {
-        LocalDate startDate = request.startDate();
-        LocalDate endDate = request.endDate();
+        LocalDate date = request.date();
         LocalTime startTime = request.startTime();
         LocalTime endTime = request.endTime();
 
-        // 시작 시간
+        // 시작 일시
         LocalDateTime startDateTime =
-                LocalDateTime.of(startDate, startTime);
+                LocalDateTime.of(date, startTime);
 
-        LocalDateTime endDateTime;
+        // 종료 일시 (자정 넘김 처리)
+        LocalDate endDate = endTime.isBefore(startTime)
+                ? date.plusDays(1)
+                : date;
 
-        if (endDate == null) {
-            // 단일 일정
-            endDateTime = LocalDateTime.of(startDate, endTime);
-        } else {
-            // 기간 일정
-            endDateTime = LocalDateTime.of(endDate, endTime);
-        }
+        LocalDateTime endDateTime =
+                LocalDateTime.of(endDate, endTime);
 
         return new BasicPlanUpdateCommand(
                 userId,

--- a/src/main/java/com/miruni/backend/domain/plan/dto/command/BasicPlanUpdateCommand.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/command/BasicPlanUpdateCommand.java
@@ -24,7 +24,7 @@ public record BasicPlanUpdateCommand(
             BasicPlanSaveRequest request
     ) {
         LocalDate startDate = request.startDate();
-        LocalDate endDate = request.endDate(); // nullable
+        LocalDate endDate = request.endDate();
         LocalTime startTime = request.startTime();
         LocalTime endTime = request.endTime();
 

--- a/src/main/java/com/miruni/backend/domain/plan/dto/command/BasicPlanUpdateCommand.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/command/BasicPlanUpdateCommand.java
@@ -4,6 +4,7 @@ package com.miruni.backend.domain.plan.dto.command;
 import com.miruni.backend.domain.plan.dto.request.BasicPlanSaveRequest;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public record BasicPlanUpdateCommand(
@@ -12,21 +13,42 @@ public record BasicPlanUpdateCommand(
         Long planId,
         String title,
         String description,
-        LocalDate scheduledDate,
-        LocalTime startTime,
-        LocalTime endTime,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime,
         String priority
 ) {
 
-    public static BasicPlanUpdateCommand of(Long userId, Long planId, BasicPlanSaveRequest request) {
+    public static BasicPlanUpdateCommand of(
+            Long userId,
+            Long planId,
+            BasicPlanSaveRequest request
+    ) {
+        LocalDate startDate = request.startDate();
+        LocalDate endDate = request.endDate(); // nullable
+        LocalTime startTime = request.startTime();
+        LocalTime endTime = request.endTime();
+
+        // 시작 시간
+        LocalDateTime startDateTime =
+                LocalDateTime.of(startDate, startTime);
+
+        LocalDateTime endDateTime;
+
+        if (endDate == null) {
+            // 단일 일정
+            endDateTime = LocalDateTime.of(startDate, endTime);
+        } else {
+            // 기간 일정
+            endDateTime = LocalDateTime.of(endDate, endTime);
+        }
+
         return new BasicPlanUpdateCommand(
                 userId,
                 planId,
                 request.title(),
                 request.description(),
-                request.scheduledDate(),
-                request.startTime(),
-                request.endTime(),
+                startDateTime,
+                endDateTime,
                 request.priority()
         );
     }

--- a/src/main/java/com/miruni/backend/domain/plan/dto/command/PlanFinishCommand.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/command/PlanFinishCommand.java
@@ -6,10 +6,9 @@ public record PlanFinishCommand(
         PlanType planType,
         Long planId,
         Long userId,
-        String expectedTime, // "HH:mm" 형식
-        String actualTime    // "HH:mm" 형식
+        String expectedTime // "HH:mm" 형식
 ) {
-    public static PlanFinishCommand of(PlanType planType, Long planId, Long userId, String expectedTime, String actualTime) {
-        return new PlanFinishCommand(planType, planId, userId, expectedTime, actualTime);
+    public static PlanFinishCommand of(PlanType planType, Long planId, Long userId, String expectedTime) {
+        return new PlanFinishCommand(planType, planId, userId, expectedTime);
     }
 }

--- a/src/main/java/com/miruni/backend/domain/plan/dto/request/BasicPlanSaveRequest.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/request/BasicPlanSaveRequest.java
@@ -24,11 +24,11 @@ public record BasicPlanSaveRequest(
         String description,
 
         @NotNull(message = "시작 날짜는 필수입니다.")
-        @Schema(description = "시작 날짜", example = "2025-11-20", type = "string", format = "date")
+        @Schema(description = "시작 날짜(00:00 ~ 23:59 사이만 입력 가능)", example = "2025-11-20", type = "string", format = "date")
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate startDate,
 
-        @Schema(description = "종료 날짜(없으면 단일 일정)", example = "2025-11-22", nullable = true, type = "string", format = "date")
+        @Schema(description = "종료 날짜(없으면 단일 일정, 00:00 ~ 23:59 사이만 입력 가능)", example = "2025-11-22", nullable = true, type = "string", format = "date")
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate endDate,
 

--- a/src/main/java/com/miruni/backend/domain/plan/dto/request/BasicPlanSaveRequest.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/request/BasicPlanSaveRequest.java
@@ -8,7 +8,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public record BasicPlanSaveRequest(
@@ -21,34 +23,28 @@ public record BasicPlanSaveRequest(
         @Schema(example = "설명입니다")
         String description,
 
-        @NotNull(message = "날짜는 필수입니다.")
-        @JsonFormat(pattern = "yyyy.MM.dd")
-        @Schema(type = "string", example = "2025.11.08")
-        LocalDate scheduledDate,
+        @NotNull(message = "시작 날짜는 필수입니다.")
+        @Schema(description = "시작 날짜", example = "2025-11-20", type = "string", format = "date")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
 
-        @NotNull(message = "시작 시각은 필수입니다.")
+        @Schema(description = "종료 날짜(없으면 단일 일정)", example = "2025-11-22", nullable = true, type = "string", format = "date")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        @NotNull(message = "시작 시간은 필수입니다.")
+        @NotNull
+        @Schema(description = "시작 시간", example = "23:00", type = "string", format = "time")
         @JsonFormat(pattern = "HH:mm")
-        @Schema(type = "string", example = "10:00")
         LocalTime startTime,
 
-        @NotNull(message = "종료 시각은 필수입니다.")
+        @NotNull(message = "종료 시간은 필수입니다.")
+        @Schema(description = "종료 시간", example = "00:30", type = "string", format = "time")
         @JsonFormat(pattern = "HH:mm")
-        @Schema(type = "string", example = "11:30")
         LocalTime endTime,
 
         @NotBlank(message = "우선 순위는 필수입니다.")
         @Schema(example = "상")
         String priority
 ) {
-    public BasicPlan toEntity(User user, Long expectedDuration, Priority mappedPriority) {
-        return BasicPlan.builder()
-                .title(this.title)
-                .description(this.description)
-                .scheduledDate(this.scheduledDate)
-                .scheduledTime(this.startTime)
-                .expectedDuration(expectedDuration)
-                .priority(mappedPriority)
-                .user(user)
-                .build();
-    }
 }

--- a/src/main/java/com/miruni/backend/domain/plan/dto/request/BasicPlanUpdateRequest.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/request/BasicPlanUpdateRequest.java
@@ -1,0 +1,34 @@
+package com.miruni.backend.domain.plan.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+
+@Schema(description = "일반 일정 수정 요청 DTO")
+public record BasicPlanUpdateRequest(
+
+        @Schema(description = "일정 제목", example = "팀 회의")
+        String title,
+
+        @Schema(description = "일정 설명", example = "주간 진행 상황 공유")
+        String description,
+
+        @Schema(description = "일정 날짜 (기준 날짜)", example = "2025-11-20", type = "string", format = "date")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate date,
+
+        @Schema(description = "시작 시간", example = "23:00", type = "string", format = "time")
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime startTime,
+
+        @Schema(description = "종료 시간 (시작 시간보다 이르면 다음 날로 자동 처리됨)", example = "00:30", type = "string", format = "time")
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime endTime,
+
+        @Schema(description = "우선순위 (상 / 중 / 하)", example = "상")
+        String priority
+) {
+}

--- a/src/main/java/com/miruni/backend/domain/plan/dto/request/PlanFinishRequest.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/request/PlanFinishRequest.java
@@ -6,11 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 @Schema(description = "일정 종료 요청 DTO")
 public record PlanFinishRequest(
 
-        @Schema(description = "예상 수행 시간 HH:mm 형식", example = "01:39")
+        @Schema(description = "실행 예정으로 설정했던 시간 HH:mm 형식", example = "01:39")
         @NotBlank
-        String expectedTime,
-
-        @Schema(description = "실제 수행 시간 HH:mm 형식", example = "00:20")
-        @NotBlank
-        String actualTime
+        String expectedTime
 ) {}

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/BasicPlanResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/BasicPlanResponse.java
@@ -4,16 +4,15 @@ import com.miruni.backend.domain.plan.entity.BasicPlan;
 import com.miruni.backend.domain.plan.entity.Priority;
 import com.miruni.backend.domain.plan.entity.Status;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 public record BasicPlanResponse(
         Long id,
         Long userId,
         String title,
         String description,
-        LocalDate scheduledDate,
-        LocalTime scheduledTime,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime,
         Long expectedDuration,
         Status status,
         Priority priority
@@ -24,8 +23,8 @@ public record BasicPlanResponse(
                 plan.getUser().getId(),
                 plan.getTitle(),
                 plan.getDescription(),
-                plan.getScheduledDate(),
-                plan.getScheduledTime(),
+                plan.getStartDateTime(),
+                plan.getEndDateTime(),
                 plan.getExpectedDuration(),
                 plan.getStatus(),
                 plan.getPriority()

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
@@ -27,7 +27,8 @@ public record DailyPlanResponse(
             Long planId,
             String title,
             String subTitle,
-            String scheduledTime,
+            String startTime,
+            String endTime,
             Priority priority,
             boolean isDone
     ) {
@@ -37,7 +38,8 @@ public record DailyPlanResponse(
                     plan.getId(),
                     plan.getTitle(),
                     null,
-                    formatTime(plan.getScheduledTime()),
+                    formatTime(plan.getStartDateTime()),
+                    formatTime(plan.getEndDateTime()),
                     plan.getPriority(),
                     plan.getStatus() == Status.DONE
             );
@@ -50,6 +52,7 @@ public record DailyPlanResponse(
                     aiPlan.getPlan().getTitle(), // TODO
                     aiPlan.getSubTitle(),
                     formatTime(aiPlan.getScheduledTime()),
+                    formatTime(aiPlan.getEndTime()),
                     aiPlan.getPlan().getPriority(),
                     aiPlan.getStatus() == Status.DONE
             );

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/PlanDetailResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/PlanDetailResponse.java
@@ -5,10 +5,7 @@ import com.miruni.backend.domain.plan.entity.BasicPlan;
 import com.miruni.backend.domain.plan.entity.Priority;
 import com.miruni.backend.domain.plan.type.PlanType;
 
-import java.time.LocalDate;
-
 import static com.miruni.backend.global.common.DateTimeFormatUtil.formatTime;
-
 
 public record PlanDetailResponse(
         PlanType planType,
@@ -16,8 +13,8 @@ public record PlanDetailResponse(
         String title,
         String subTitle, // AI
         String description, // BASIC
-        LocalDate scheduledDate,
-        String scheduledTime,
+        String startTime,
+        String endTime,
         Priority priority
 ) {
     public static PlanDetailResponse fromBasic(BasicPlan basicPlan) {
@@ -27,8 +24,8 @@ public record PlanDetailResponse(
                 basicPlan.getTitle(),
                 null,
                 basicPlan.getDescription(),
-                basicPlan.getScheduledDate(),
-                formatTime(basicPlan.getScheduledTime()),
+                formatTime(basicPlan.getStartDateTime()),
+                formatTime(basicPlan.getEndDateTime()),
                 basicPlan.getPriority()
         );
     }
@@ -40,8 +37,8 @@ public record PlanDetailResponse(
                 aiPlan.getPlan().getTitle(),
                 aiPlan.getSubTitle(),
                 null,
-                aiPlan.getScheduledDate(),
                 formatTime(aiPlan.getScheduledTime()),
+                formatTime(aiPlan.getEndTime()),
                 aiPlan.getPlan().getPriority()
         );
     }

--- a/src/main/java/com/miruni/backend/domain/plan/entity/BasicPlan.java
+++ b/src/main/java/com/miruni/backend/domain/plan/entity/BasicPlan.java
@@ -53,7 +53,6 @@ public class BasicPlan extends BaseEntity {
 
     public void update(String title, String description, LocalDateTime startDateTime,
                        LocalDateTime endDateTime, Priority priority) {
-        validateTimeRange(startDateTime, endDateTime);
 
         this.title = title;
         this.description = description;
@@ -77,11 +76,6 @@ public class BasicPlan extends BaseEntity {
                 .build();
     }
 
-    private static void validateTimeRange(LocalDateTime start, LocalDateTime end) {
-        if (start.isAfter(end)) {
-            throw BaseException.type(BasicPlanErrorCode.INVALID_TIME_RANGE);
-        }
-    }
 
     public void complete() { this.status = Status.DONE; }
     public void start() { this.status = Status.IN_PROGRESS; }

--- a/src/main/java/com/miruni/backend/domain/plan/entity/BasicPlan.java
+++ b/src/main/java/com/miruni/backend/domain/plan/entity/BasicPlan.java
@@ -8,8 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -34,14 +33,11 @@ public class BasicPlan extends BaseEntity {
     @Column(name = "description", nullable = false, columnDefinition = "TEXT")
     private String description;
 
-    @Column(name = "scheduled_date", nullable = false)
-    private LocalDate scheduledDate;
+    @Column(name = "start_date_time", nullable = false)
+    private LocalDateTime startDateTime;
 
-    @Column(name = "scheduled_time", nullable = false)
-    private LocalTime scheduledTime;
-
-    @Column(name = "end_time", nullable = false)
-    private LocalTime endTime;
+    @Column(name = "end_date_time", nullable = false)
+    private LocalDateTime endDateTime;
 
     @Column(name = "expected_duration", nullable = false)
     private Long expectedDuration;
@@ -55,36 +51,33 @@ public class BasicPlan extends BaseEntity {
     @Column(name = "priority", length = 10)
     private Priority priority;
 
-    public void update(String title, String description, LocalDate scheduledDate,
-                       LocalTime startTime, LocalTime endTime, Priority priority) {
-        validateTimeRange(startTime, endTime);
+    public void update(String title, String description, LocalDateTime startDateTime,
+                       LocalDateTime endDateTime, Priority priority) {
+        validateTimeRange(startDateTime, endDateTime);
 
         this.title = title;
         this.description = description;
-        this.scheduledDate = scheduledDate;
-        this.scheduledTime = startTime;
-        this.endTime = endTime;
-        this.expectedDuration = Duration.between(startTime, endTime).toMinutes();
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+        this.expectedDuration = Duration.between(startDateTime, endDateTime).toMinutes();
         this.priority = priority;
     }
 
-    public static BasicPlan create(User user, String title, String description, LocalDate scheduledDate,
-                            LocalTime startTime, LocalTime endTime, Priority priority) {
-        validateTimeRange(startTime, endTime);
-        long expectedDuration = Duration.between(startTime, endTime).toMinutes();
+    public static BasicPlan create(User user, String title, String description, LocalDateTime startDateTime,
+                            LocalDateTime endDateTime, Priority priority) {
+        long expectedDuration = Duration.between(startDateTime, endDateTime).toMinutes();
         return BasicPlan.builder()
                 .user(user)
                 .title(title)
                 .description(description)
-                .scheduledDate(scheduledDate)
-                .scheduledTime(startTime)
-                .endTime(endTime)
+                .startDateTime(startDateTime)
+                .endDateTime(endDateTime)
                 .expectedDuration(expectedDuration)
                 .priority(priority)
                 .build();
     }
 
-    private static void validateTimeRange(LocalTime start, LocalTime end) {
+    private static void validateTimeRange(LocalDateTime start, LocalDateTime end) {
         if (start.isAfter(end)) {
             throw BaseException.type(BasicPlanErrorCode.INVALID_TIME_RANGE);
         }
@@ -93,8 +86,8 @@ public class BasicPlan extends BaseEntity {
     public void complete() { this.status = Status.DONE; }
     public void start() { this.status = Status.IN_PROGRESS; }
     public void pause() { this.status = Status.TODO; }
-    public void rescheduleTime(LocalTime newScheduledTime) {
-        this.scheduledTime = newScheduledTime;
-        this.endTime = newScheduledTime.plusMinutes(this.getExpectedDuration());
+    public void rescheduleTime(LocalDateTime newScheduledTime) {
+        this.startDateTime = newScheduledTime;
+        this.endDateTime = newScheduledTime.plusMinutes(this.getExpectedDuration());
     }
 }

--- a/src/main/java/com/miruni/backend/domain/plan/exception/BasicPlanErrorCode.java
+++ b/src/main/java/com/miruni/backend/domain/plan/exception/BasicPlanErrorCode.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpStatus;
 public enum BasicPlanErrorCode implements ErrorCode {
 
     INVALID_PRIORITY_VALUE(HttpStatus.BAD_REQUEST, "BASICPLAN400_1", "잘못된 우선순위 값입니다. 우선순위 값은 '상', '중', '하' 중 하나여야 합니다."),
-    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "BASICPLAN400_2", "일정 시작 시각은 종료 시각보다 이전이어야 합니다."),
     BASIC_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "BASICPLAN400_3", "일반 일정을 찾을 수 없습니다."),
     BASIC_PLAN_FORBIDDEN(HttpStatus.FORBIDDEN, "BASICPLAN403_1", "해당 일정에 대한 권한이 없습니다."),
     BASIC_PLAN_CONFLICT(HttpStatus.BAD_REQUEST, "BASICPLAN400_004", "같은 시간에 다른 일정이 예정되어 있습니다.");

--- a/src/main/java/com/miruni/backend/domain/plan/repository/AiPlanRepository.java
+++ b/src/main/java/com/miruni/backend/domain/plan/repository/AiPlanRepository.java
@@ -16,14 +16,12 @@ import java.util.Optional;
 public interface AiPlanRepository extends JpaRepository<AiPlan, Long> {
 
     @Query("""
-        SELECT new com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse(
-            a.scheduledDate,
-            COUNT(a)
-        )
+        SELECT a.scheduledDate, COUNT(a)
         FROM AiPlan a
         WHERE a.plan.user.id = :userId
           AND a.status != com.miruni.backend.domain.plan.entity.Status.DONE
-          AND a.scheduledDate BETWEEN :startDate AND :endDate
+          AND a.scheduledDate >= :startDate
+          AND a.scheduledDate <= :endDate
         GROUP BY a.scheduledDate
         ORDER BY a.scheduledDate
     """)
@@ -44,9 +42,13 @@ public interface AiPlanRepository extends JpaRepository<AiPlan, Long> {
             @Param("userId") Long userId,
             @Param("date") LocalDate date
     );
+
     Optional<AiPlan> findByIdAndPlanUserId(Long id, Long userId);
+
     List<AiPlan> findByPlanId(Long planId);
+
     boolean existsByPlanUserIdAndScheduledTime(Long userId, LocalTime scheduledTime);
+
     @Query("""
         SELECT COUNT(a) > 0
         FROM AiPlan a

--- a/src/main/java/com/miruni/backend/domain/plan/repository/BasicPlanRepository.java
+++ b/src/main/java/com/miruni/backend/domain/plan/repository/BasicPlanRepository.java
@@ -19,35 +19,37 @@ public interface BasicPlanRepository extends JpaRepository<BasicPlan, Long> {
 
     @Query("""
         SELECT new com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse(
-             b.scheduledDate,
-             COUNT(b)
-         )
+            CAST(b.startDateTime AS LocalDate),
+            COUNT(b)
+        )
         FROM BasicPlan b
         WHERE b.user.id = :userId
           AND b.status != com.miruni.backend.domain.plan.entity.Status.DONE
-          AND b.scheduledDate BETWEEN :startDate AND :endDate
-        GROUP BY b.scheduledDate
-        ORDER BY b.scheduledDate
+          AND b.startDateTime >= :startDateTime
+          AND b.startDateTime < :endDateTime
+        GROUP BY CAST(b.startDateTime AS LocalDate)
+        ORDER BY CAST(b.startDateTime AS LocalDate)
     """)
     List<MonthlyPlanResponse> countUnfinishedBasicPlansByDate(
             @Param("userId") Long userId,
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
     );
-
 
     @Query("""
         SELECT b
         FROM BasicPlan b
         WHERE b.user.id = :userId
-          AND b.scheduledDate = :date
-        ORDER BY b.scheduledTime
+          AND FUNCTION('DATE', b.startDateTime) = :date
+        ORDER BY b.startDateTime
     """)
     List<BasicPlan> findDailyBasicPlans(
             @Param("userId") Long userId,
             @Param("date") LocalDate date
     );
+
     //boolean existsByUserIdAndScheduledTime(Long userId, LocalTime scheduledTime);
+
     //boolean existsByUserIdAndScheduledStartTime(Long userId, LocalTime scheduledTime);
 
     @Query("""
@@ -77,5 +79,4 @@ public interface BasicPlanRepository extends JpaRepository<BasicPlan, Long> {
             @Param("reqStartDateTime") LocalDateTime reqStartDateTime,
             @Param("reqEndDateTime") LocalDateTime reqEndDateTime
     );
-
 }

--- a/src/main/java/com/miruni/backend/domain/plan/repository/BasicPlanRepository.java
+++ b/src/main/java/com/miruni/backend/domain/plan/repository/BasicPlanRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.time.LocalTime;
 import java.util.Optional;
@@ -53,30 +54,28 @@ public interface BasicPlanRepository extends JpaRepository<BasicPlan, Long> {
         SELECT COUNT(b) > 0
         FROM BasicPlan b
         WHERE b.user.id = :userId
-            AND b.scheduledDate = :date
-            AND (b.scheduledTime < :reqEndTime AND b.endTime > :reqStartTime)
+              AND b.startDateTime < :reqEndDateTime
+              AND b.endDateTime > :reqStartDateTime
     """)
     boolean existsOverlap(
             @Param("userId") Long userId,
-            @Param("date") LocalDate date,
-            @Param("reqStartTime") LocalTime reqStartTime,
-            @Param("reqEndTime") LocalTime reqEndTime
+            @Param("reqStartDateTime") LocalDateTime reqStartDateTime,
+            @Param("reqEndDateTime") LocalDateTime reqEndDateTime
     );
 
     @Query("""
         SELECT COUNT(b) > 0
         FROM BasicPlan b
         WHERE b.user.id = :userId
-            AND b.id != :excludeId
-            AND b.scheduledDate = :date
-            AND (b.scheduledTime < :reqEndTime AND b.endTime > :reqStartTime)
+              AND b.id != :excludeId
+              AND b.startDateTime < :reqEndDateTime
+              AND b.endDateTime > :reqStartDateTime
     """)
     boolean existsOverlapWithinUpdate(
             @Param("userId") Long userId,
             @Param("excludeId") Long excludeId,
-            @Param("date") LocalDate date,
-            @Param("reqStartTime") LocalTime reqStartTime,
-            @Param("reqEndTime") LocalTime reqEndTime
+            @Param("reqStartDateTime") LocalDateTime reqStartDateTime,
+            @Param("reqEndDateTime") LocalDateTime reqEndDateTime
     );
 
 }

--- a/src/main/java/com/miruni/backend/domain/plan/service/BasicPlanCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/BasicPlanCommandService.java
@@ -15,11 +15,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -89,7 +87,7 @@ public class BasicPlanCommandService {
             }
         }
 
-        // 검증 모두 통과하면 한 번에 저장
+        // 여러 일정들 검증 모두 통과하면 한 번에 저장
         basicPlanRepository.saveAll(plans);
 
         return plans.stream()

--- a/src/main/java/com/miruni/backend/domain/plan/service/BasicPlanCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/BasicPlanCommandService.java
@@ -15,6 +15,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -25,47 +33,85 @@ public class BasicPlanCommandService {
     private final BasicPlanQueryService basicPlanQueryService;
     private final ScheduleValidator scheduleValidator;
 
-    public BasicPlanResponse createBasicPlan(BasicPlanCreateCommand command) {
+    public List<BasicPlanResponse> createBasicPlan(BasicPlanCreateCommand command) {
+
         User user = userQueryService.getUserById(command.userId());
+        List<BasicPlan> plans = new ArrayList<>();
 
-        scheduleValidator.validateConflict(
-                user.getId(),
-                command.scheduledDate(),
-                command.startTime(),
-                command.endTime()
-        );
+        LocalDate startDate = command.startDate();
+        LocalDate endDate = command.endDate(); // nullable
+        LocalTime startTime = command.startTime();
+        LocalTime endTime = command.endTime();
 
-        BasicPlan plan = BasicPlan.create(
-                user,
-                command.title(),
-                command.description(),
-                command.scheduledDate(),
-                command.startTime(),
-                command.endTime(),
-                mapPriority(command.priority())
-        );
+        boolean crossMidnight = endTime.isBefore(startTime);
 
-        basicPlanRepository.save(plan);
-        return BasicPlanResponse.from(plan);
+        //단일 일정
+        if (endDate == null) {
+            LocalDateTime startDateTime = LocalDateTime.of(startDate, startTime);
+            LocalDateTime endDateTime = LocalDateTime.of(
+                    crossMidnight ? startDate.plusDays(1) : startDate,
+                    endTime
+            );
+
+            scheduleValidator.validateConflict(user.getId(), startDateTime, endDateTime);
+
+            plans.add(BasicPlan.create(
+                    user,
+                    command.title(),
+                    command.description(),
+                    startDateTime,
+                    endDateTime,
+                    mapPriority(command.priority())
+            ));
+
+        } else {
+            //기간 일정
+            LocalDate current = startDate;
+
+            while (!current.isAfter(endDate)) {
+                LocalDateTime dayStart = LocalDateTime.of(current, startTime);
+                LocalDateTime dayEnd = LocalDateTime.of(
+                        crossMidnight ? current.plusDays(1) : current,
+                        endTime
+                );
+                scheduleValidator.validateConflict(user.getId(), dayStart, dayEnd);
+
+                plans.add(BasicPlan.create(
+                        user,
+                        command.title(),
+                        command.description(),
+                        dayStart,
+                        dayEnd,
+                        mapPriority(command.priority())
+                ));
+
+                current = current.plusDays(1);
+            }
+        }
+
+        // 검증 모두 통과하면 한 번에 저장
+        basicPlanRepository.saveAll(plans);
+
+        return plans.stream()
+                .map(BasicPlanResponse::from)
+                .toList();
     }
 
     public BasicPlanResponse updateBasicPlan(BasicPlanUpdateCommand command) {
         BasicPlan plan = basicPlanQueryService.getByPlanIdAndUserId(command.planId(), command.userId());
 
-        scheduleValidator.validateConflict(
+        scheduleValidator.validateConflictForBasicPlan(
                 command.userId(),
                 command.planId(),
-                command.scheduledDate(),
-                command.startTime(),
-                command.endTime()
+                command.startDateTime(),
+                command.endDateTime()
         );
 
         plan.update(
                 command.title(),
                 command.description(),
-                command.scheduledDate(),
-                command.startTime(),
-                command.endTime(),
+                command.startDateTime(),
+                command.endDateTime(),
                 mapPriority(command.priority())
         );
         return BasicPlanResponse.from(plan);

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanCommandService.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -41,15 +42,6 @@ public class PlanCommandService {
         LocalDateTime now = LocalDateTime.now();
         int durationMinutes = parseTimeToMinutes(request.durationStr());
         LocalDateTime endDateTime = now.plusMinutes(durationMinutes);
-
-        LocalDate date = now.toLocalDate();
-        LocalTime startTime = now.toLocalTime();
-        LocalTime endTimeOnly = endDateTime.toLocalTime();
-
-        if (!endTimeOnly.isAfter(startTime)) {
-            endDateTime = endDateTime.plusDays(1);
-            endTimeOnly = endDateTime.toLocalTime();
-        }
 
         if (request.planType() == PlanType.BASIC) {
             scheduleValidator.validateConflictForBasicPlan(request.userId(), request.planId(), now, endDateTime);
@@ -75,18 +67,20 @@ public class PlanCommandService {
         User user = userQueryService.getUserById(command.userId());
 
         int expectedMinutes = parseTimeToMinutes(command.expectedTime());
-        int actualMinutes = parseTimeToMinutes(command.actualTime());
-        int peanutCount = calculatePeanuts(expectedMinutes, actualMinutes);
+        int actualMinutes;
 
        Status status;
        switch (command.planType()) {
            case BASIC -> {
-               BasicPlan basicplan = getBasicPlan(command.planId(), command.userId());
-               basicplan.complete();
-               status = basicplan.getStatus();
+               BasicPlan basicPlan = getBasicPlan(command.planId(), command.userId());
+               actualMinutes = (int) Duration.between(basicPlan.getUpdatedAt(), LocalDateTime.now()).toMinutes();
+               basicPlan.complete();
+               status = basicPlan.getStatus();
            }
            case AI -> {
                AiPlan aiPlan = getAiPlan(command.planId(), command.userId());
+               actualMinutes = (int) Duration.between(aiPlan.getUpdatedAt(), LocalDateTime.now()).toMinutes();
+
                aiPlan.complete();
                status = aiPlan.getStatus();
 
@@ -96,6 +90,7 @@ public class PlanCommandService {
            default -> throw BaseException.type(PlanErrorCode.PLAN_TYPE_NOT_FOUND);
        }
 
+        int peanutCount = calculatePeanuts(expectedMinutes, actualMinutes);
         user.addPeanuts(peanutCount);
 
         return PlanFinishResponse.of(peanutCount, command.planType(), command.planId(), status);

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanCommandService.java
@@ -40,13 +40,22 @@ public class PlanCommandService {
     public PlanStartResponse startPlan(PlanStartRequest request) {
         LocalDateTime now = LocalDateTime.now();
         int durationMinutes = parseTimeToMinutes(request.durationStr());
-        LocalDateTime endTime = now.plusMinutes(durationMinutes);
+        LocalDateTime endDateTime = now.plusMinutes(durationMinutes);
 
         LocalDate date = now.toLocalDate();
         LocalTime startTime = now.toLocalTime();
-        LocalTime endTimeOnly = endTime.toLocalTime();
+        LocalTime endTimeOnly = endDateTime.toLocalTime();
 
-        scheduleValidator.validateConflict(request.userId(), request.planId(), date, startTime, endTimeOnly);
+        if (!endTimeOnly.isAfter(startTime)) {
+            endDateTime = endDateTime.plusDays(1);
+            endTimeOnly = endDateTime.toLocalTime();
+        }
+
+        if (request.planType() == PlanType.BASIC) {
+            scheduleValidator.validateConflictForBasicPlan(request.userId(), request.planId(), now, endDateTime);
+        } else if (request.planType() == PlanType.AI) {
+            scheduleValidator.validateConflictForAiPlan(request.userId(), request.planId(), now, endDateTime);
+        }
 
         // 일정 상태 변경
         if (request.planType() == PlanType.BASIC) {
@@ -94,31 +103,46 @@ public class PlanCommandService {
 
     public PlanPauseResponse pausePlan(PlanPauseCommand command) {
         LocalTime newScheduledTime = LocalTime.parse(command.resumeTime());
+        LocalDate today = LocalDate.now();
 
         long expectedDurationMinutes;
         switch (command.planType()) {
             case BASIC -> {
                 BasicPlan plan = getBasicPlan(command.planId(), command.userId());
                 expectedDurationMinutes = plan.getExpectedDuration();
-                scheduleValidator.validateConflict(
+
+                LocalDateTime startDateTime = LocalDateTime.of(today, newScheduledTime);
+                LocalDateTime endDateTime = startDateTime.plusMinutes(expectedDurationMinutes);
+
+                if (!endDateTime.isAfter(startDateTime)) {
+                    endDateTime = endDateTime.plusDays(1);
+                }
+
+                scheduleValidator.validateConflictForBasicPlan(
                         command.userId(),
                         command.planId(),
-                        LocalDate.now(),
-                        newScheduledTime,
-                        newScheduledTime.plusMinutes(expectedDurationMinutes)
+                        startDateTime,
+                        endDateTime
                 );
                 plan.pause();
-                plan.rescheduleTime(newScheduledTime);
+                plan.rescheduleTime(startDateTime);
             }
             case AI -> {
                 AiPlan plan = getAiPlan(command.planId(), command.userId());
                 expectedDurationMinutes = (long) plan.getExpectedDuration();
-                scheduleValidator.validateConflict(
+
+                LocalDateTime startDateTime = LocalDateTime.of(today, newScheduledTime);
+                LocalDateTime endDateTime = startDateTime.plusMinutes(expectedDurationMinutes);
+
+                if (!endDateTime.isAfter(startDateTime)) {
+                    endDateTime = endDateTime.plusDays(1);
+                }
+
+                scheduleValidator.validateConflictForAiPlan(
                         command.userId(),
                         command.planId(),
-                        LocalDate.now(),
-                        newScheduledTime,
-                        newScheduledTime.plusMinutes(expectedDurationMinutes)
+                        startDateTime,
+                        endDateTime
                 );
                 plan.pause();
                 plan.rescheduleTime(newScheduledTime);

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +45,10 @@ public class PlanQueryService {
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
-        List<MonthlyPlanResponse> basicPlans = basicPlanRepository.countUnfinishedBasicPlansByDate(userId, startDate, endDate);
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.plusDays(1).atStartOfDay();
+
+        List<MonthlyPlanResponse> basicPlans = basicPlanRepository.countUnfinishedBasicPlansByDate(userId, startDateTime, endDateTime);
         List<MonthlyPlanResponse> aiPlans = aiPlanRepository.countUnfinishedAiPlansByDate(userId, startDate, endDate);
 
         return Stream.concat(basicPlans.stream(), aiPlans.stream())
@@ -71,7 +75,7 @@ public class PlanQueryService {
                         aiPlanRepository.findDailyAiPlans(userId, date).stream()
                                 .map(DailyPlanResponse.DailyPlanItemResponse::fromAi)
                 )
-                .sorted(Comparator.comparing(DailyPlanResponse.DailyPlanItemResponse::scheduledTime))
+                .sorted(Comparator.comparing(DailyPlanResponse.DailyPlanItemResponse::startTime))
                 .toList();
 
         Map<Boolean, List<DailyPlanResponse.DailyPlanItemResponse>> plansByStatus = plans.stream()

--- a/src/main/java/com/miruni/backend/domain/plan/validator/ScheduleValidator.java
+++ b/src/main/java/com/miruni/backend/domain/plan/validator/ScheduleValidator.java
@@ -8,8 +8,8 @@ import com.miruni.backend.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
+
 
 @Component
 @RequiredArgsConstructor
@@ -17,28 +17,44 @@ public class ScheduleValidator {
     private final AiPlanRepository aiPlanRepository;
     private final BasicPlanRepository basicPlanRepository;
 
-    public void validateConflict(Long userId, LocalDate date, LocalTime startTime, LocalTime endTime) {
-
-        if (basicPlanRepository.existsOverlap(userId, date, startTime, endTime)) {
+    public void validateConflict(Long userId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        if (basicPlanRepository.existsOverlap(userId, startDateTime, endDateTime)) {
             throw BaseException.type(BasicPlanErrorCode.BASIC_PLAN_CONFLICT);
         }
 
-        if(aiPlanRepository.existsOverlap(userId, date, startTime, endTime)) {
-            throw BaseException.type(AiPlanErrorCode.AI_PLAN_CONFLICT);
-        }
+//        if (aiPlanRepository.existsOverlap(userId, startDateTime, endDateTime)) {
+//            throw BaseException.type(AiPlanErrorCode.AI_PLAN_CONFLICT);
+//        }
     }
 
     // 오버로딩
-    public void validateConflict(Long userId, Long excludeId, LocalDate date, LocalTime startTime, LocalTime endTime) {
+
+    //BasicPlan
+    public void validateConflictForBasicPlan(Long userId, Long excludeId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
 
         // BasicPlan 검증
-        if (basicPlanRepository.existsOverlapWithinUpdate(userId, excludeId, date, startTime, endTime)) {
+        if (basicPlanRepository.existsOverlapWithinUpdate(userId, excludeId, startDateTime, endDateTime)) {
             throw BaseException.type(BasicPlanErrorCode.BASIC_PLAN_CONFLICT);
         }
 
         // AiPlan 검증
-        if (aiPlanRepository.existsOverlapWithinUpdate(userId, excludeId, date, startTime, endTime)) {
-            throw BaseException.type(AiPlanErrorCode.AI_PLAN_CONFLICT);
-        }
+//        if (aiPlanRepository.existsOverlap(userId, startDateTime, endDateTime)) {
+//            throw BaseException.type(AiPlanErrorCode.AI_PLAN_CONFLICT);
+//        }
     }
+
+    //AiPlan
+    public void validateConflictForAiPlan(Long userId, Long excludeId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+
+        // BasicPlan 검증
+        if (basicPlanRepository.existsOverlap(userId, startDateTime, endDateTime)) {
+            throw BaseException.type(BasicPlanErrorCode.BASIC_PLAN_CONFLICT);
+        }
+
+        // AiPlan 검증
+//        if (aiPlanRepository.existsOverlapWithinUpdate(userId, excludeId, startDateTime, endDateTime)) {
+//            throw BaseException.type(AiPlanErrorCode.AI_PLAN_CONFLICT);
+//        }
+    }
+
 }

--- a/src/main/java/com/miruni/backend/global/config/FcmConfig.java
+++ b/src/main/java/com/miruni/backend/global/config/FcmConfig.java
@@ -50,11 +50,11 @@ public class FcmConfig {
         // try (InputStream serviceAccount = new ClassPathResource(fcmKeyPath).getInputStream()) {
         try {
             FileInputStream serviceAccount = new FileInputStream(fcmKeyPath);
-            
+
             FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
                     .build();
-                    
+
             return FirebaseApp.initializeApp(options);
         } catch (IOException e) {
             throw new RuntimeException(e.getMessage());


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #35
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 일반 일정 단일/기간 설정 기능 구현
- 일정 중복 검증 메서드 BasicPlan용/AIPlan용으로 분리

[단일 날짜 선택] 20일 오후 11:00-오전 00:30
startDateTime 20일 오후 11:00, endDateTime 21일 오전 00:30
[단일 날짜 선택] 20일 오전 10:00-오전 11:30
startDateTime 20일 오전 10:00, endDateTime 20일 오전 11:30

[기간 설정] 20-21일 오후 11:00-오전 00:30
-> startDateTime 20일 오후 11:00, endDateTime 21일 오전 00:30
-> startDateTime 21일 오후 11:00, endDateTime 22일 오전 00:30
=> 총 일정 2개 추가
[기간 설정] 20-22 오전 11:00-오후 13:00
-> 20,21,22일 각각오전 11:00~오후 13:00으로 총 일정 3개 추가

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
기존 BasicPlan 엔티티에서 분리되어 있던 날짜(LocalDate)와 시간(LocalTime)을 LocalDateTime으로 통합하였습니다!  DB 초기화해주시면 감사하겠습니다!

