### PR TITLE
[refactor] #46 단일/기간 ai 플래닝 정책사항 반영

### DIFF
--- a/src/main/java/com/miruni/backend/domain/plan/controller/PlanApi.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/PlanApi.java
@@ -21,32 +21,32 @@ import java.util.List;
 @Tag(name="plan", description = "일정 분할/조회/관리/실행 API")
 public interface PlanApi {
 
-//    @Operation(
-//            summary = "홈페이지 일정 조회",
-//            description = "오늘의 미완료 일정을 조회합니다."
-//    )
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "홈페이지 일정 조회 성공")
-//    })
-//    PlanHomeResponse getPlanHome(@LoginUser Long userId);
+    @Operation(
+            summary = "홈페이지 일정 조회",
+            description = "오늘의 미완료 일정을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "홈페이지 일정 조회 성공")
+    })
+    PlanHomeResponse getPlanHome(@LoginUser Long userId);
 
-//    @Operation(
-//            summary = "캘린더 조회",
-//            description = "특정 년/월의 날짜별 미완료 일정 개수를 조회합니다."
-//    )
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "캘린더 조회 성공")
-//    })
-//    List<MonthlyPlanResponse> getMonthlyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month);
+    @Operation(
+            summary = "캘린더 조회",
+            description = "특정 년/월의 날짜별 미완료 일정 개수를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "캘린더 조회 성공")
+    })
+    List<MonthlyPlanResponse> getMonthlyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month);
 
-//    @Operation(
-//            summary = "특정 날짜의 완료/미완료 일정 조회",
-//            description = "특정 날짜의 완료/미완료 일정을 조회합니다."
-//    )
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "일정 조회 성공")
-//    })
-//    DailyPlanResponse getDailyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month, @RequestParam int day);
+    @Operation(
+            summary = "특정 날짜의 완료/미완료 일정 조회",
+            description = "특정 날짜의 완료/미완료 일정을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일정 조회 성공")
+    })
+    DailyPlanResponse getDailyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month, @RequestParam int day);
 
     @Operation(
             summary = "특정 일정 조회",

--- a/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/miruni/backend/domain/plan/controller/PlanController.java
@@ -18,8 +18,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-import jakarta.validation.Valid;
-
 @RestController
 @RequestMapping("/api/plans")
 @RequiredArgsConstructor
@@ -29,20 +27,20 @@ public class PlanController implements PlanApi{
     private final PlanCommandService planCommandService;
     private final PlanQueryService planQueryService;
 
-//    @GetMapping("/home")
-//    public PlanHomeResponse getPlanHome(@LoginUser Long userId) {
-//        return planQueryService.getPlanHome(userId);
-//    }
-//
-//    @GetMapping("/monthly")
-//    public List<MonthlyPlanResponse> getMonthlyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month) {
-//        return planQueryService.getMonthlyPlan(userId, year, month);
-//    }
-//
-//    @GetMapping("/daily")
-//    public DailyPlanResponse getDailyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month, @RequestParam int day) {
-//        return planQueryService.getDailyPlan(userId, year, month, day);
-//    }
+    @GetMapping("/home")
+    public PlanHomeResponse getPlanHome(@LoginUser Long userId) {
+        return planQueryService.getPlanHome(userId);
+    }
+
+    @GetMapping("/monthly")
+    public List<MonthlyPlanResponse> getMonthlyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month) {
+        return planQueryService.getMonthlyPlan(userId, year, month);
+    }
+
+    @GetMapping("/daily")
+    public DailyPlanResponse getDailyPlans(@LoginUser Long userId, @RequestParam int year, @RequestParam int month, @RequestParam int day) {
+        return planQueryService.getDailyPlan(userId, year, month, day);
+    }
 
     @GetMapping("/{planId}")
     public PlanDetailResponse getPlanDetail(@LoginUser Long userId, @PathVariable Long planId, @RequestParam PlanType planType) {

--- a/src/main/java/com/miruni/backend/domain/plan/dto/command/AiPlanCreateCommandDto.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/command/AiPlanCreateCommandDto.java
@@ -1,17 +1,18 @@
 package com.miruni.backend.domain.plan.dto.command;
 
 import com.miruni.backend.domain.plan.dto.request.AiPlanCreateRequest;
-import com.miruni.backend.domain.plan.entity.Plan;
 import com.miruni.backend.domain.plan.entity.Priority;
 import com.miruni.backend.domain.plan.entity.TimePeriod;
-import java.time.LocalDate;
+
+import java.time.LocalDateTime;
 
 public record AiPlanCreateCommandDto(
         Long planId,
         String title,
-        LocalDate deadline,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime,
         TimePeriod timePeriod,
-        String taskRange,
+        String scope,
         Priority priority,
         String detailRequest
         ) {
@@ -19,9 +20,10 @@ public record AiPlanCreateCommandDto(
         return new AiPlanCreateCommandDto(
                 planId,
                 request.title(),
-                request.deadline(),
+                request.startDateTime(),
+                request.endDateTime(),
                 request.timePeriod(),
-                request.taskRange(),
+                request.scope(),
                 request.priority(),
                 request.detailRequest()
         );

--- a/src/main/java/com/miruni/backend/domain/plan/dto/command/PlanCreateCommandDto.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/command/PlanCreateCommandDto.java
@@ -1,16 +1,15 @@
 package com.miruni.backend.domain.plan.dto.command;
 
 import com.miruni.backend.domain.plan.dto.request.AiPlanCreateRequest;
-import com.miruni.backend.domain.plan.entity.Plan;
 import com.miruni.backend.domain.plan.entity.Priority;
-import com.miruni.backend.domain.plan.entity.TimePeriod;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record PlanCreateCommandDto(
         Long userId,
         String title,
-        LocalDate deadline,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime,
         String taskRange,
         Priority priority
 ) {
@@ -18,8 +17,9 @@ public record PlanCreateCommandDto(
         return new PlanCreateCommandDto(
                 userId,
                 request.title(),
-                request.deadline(),
-                request.taskRange(),
+                request.startDateTime(),
+                request.endDateTime(),
+                request.scope(),
                 request.priority()
         );
     }

--- a/src/main/java/com/miruni/backend/domain/plan/dto/request/AiPlanCreateRequest.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/request/AiPlanCreateRequest.java
@@ -1,14 +1,12 @@
 package com.miruni.backend.domain.plan.dto.request;
 
-import com.miruni.backend.domain.plan.entity.Plan;
 import com.miruni.backend.domain.plan.entity.Priority;
 import com.miruni.backend.domain.plan.entity.TimePeriod;
-import com.miruni.backend.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record AiPlanCreateRequest(
         @NotBlank
@@ -16,8 +14,12 @@ public record AiPlanCreateRequest(
         String title,
 
         @NotNull
-        @Schema(description = "마감기한", example = "2026-05-01")
-        LocalDate deadline,
+        @Schema(description = "시작날짜시간", example = "2026-05-01T11:00:00")
+        LocalDateTime startDateTime,
+
+        @NotNull
+        @Schema(description = "종료날짜시간", example = "2026-05-07T09:00:00")
+        LocalDateTime endDateTime,
 
         @NotNull
         @Schema(description = "실행시간대", example = "MORNING")
@@ -25,7 +27,7 @@ public record AiPlanCreateRequest(
 
         @NotBlank
         @Schema(description = "일정 범위", example = "슬라이드 13장 제작")
-        String taskRange,
+        String scope,
 
         @NotNull
         @Schema(description = "우선 순위", example = "HIGH")

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/AiPlanCreateResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/AiPlanCreateResponse.java
@@ -24,12 +24,12 @@ public record AiPlanCreateResponse(
         String title,
 
         @NotNull
-        @Schema(description = "마감기한", example = "2025-12-31")
+        @Schema(description = "마감기한", example = "2026-03-01T11:00:00")
         LocalDate deadline,
 
         @NotBlank
         @Schema(description = "일정 범위", example = "기획안 13페이지 작성")
-        String taskRange,
+        String scope,
 
         @NotNull
         @Schema(description = "우선 순위", example = "HIGH")
@@ -60,7 +60,7 @@ public record AiPlanCreateResponse(
                         plan.getId(),
                         aiPlan.getId(),
                         plan.getTitle(),
-                        plan.getDeadline().toLocalDate(),
+                        plan.getEndDateTime().toLocalDate(),
                         plan.getScope(),
                         plan.getPriority(),
                         aiPlan.getStartDateTime().toLocalDate(),

--- a/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
+++ b/src/main/java/com/miruni/backend/domain/plan/dto/response/DailyPlanResponse.java
@@ -49,7 +49,7 @@ public record DailyPlanResponse(
             return new DailyPlanItemResponse(
                     PlanType.AI,
                     aiPlan.getId(),
-                    aiPlan.getPlan().getTitle(), // TODO
+                    aiPlan.getPlan().getTitle(),
                     aiPlan.getSubTitle(),
                     formatTime(aiPlan.getStartDateTime()),
                     formatTime(aiPlan.getEndDateTime()),

--- a/src/main/java/com/miruni/backend/domain/plan/entity/Plan.java
+++ b/src/main/java/com/miruni/backend/domain/plan/entity/Plan.java
@@ -28,8 +28,11 @@ public class Plan extends BaseEntity {
     @Column(name = "title", nullable = false, length = 50)
     private String title;
 
-    @Column(name = "deadline", nullable = false)
-    private LocalDateTime deadline;
+    @Column(name = "startDateTime", nullable = false)
+    private LocalDateTime startDateTime;
+
+    @Column(name = "endDateTime", nullable = false)
+    private LocalDateTime endDateTime;
 
     @Column(name = "is_done", nullable = false)
     private boolean isDone = false;
@@ -48,7 +51,7 @@ public class Plan extends BaseEntity {
     private List<AiPlan> aiPlans = new ArrayList<>();
 
     public void updateTitle(String title) {this.title = title;}
-    public void updateDeadline(LocalDate deadline) {this.deadline = deadline.atStartOfDay();}
+    public void updateDeadline(LocalDate deadline) {this.startDateTime = deadline.atStartOfDay();}
     public void updateScope(String scope) {this.scope = scope;}
     public void updatePriority(Priority priority) {this.priority = priority;}
 
@@ -56,22 +59,25 @@ public class Plan extends BaseEntity {
     private Plan(
             User user,
             final String title,
-            final LocalDateTime deadline,
+            final LocalDateTime startDateTime,
+            final LocalDateTime endDateTime,
             final String scope,
             final Priority priority
     ){
         this.user = user;
         this.title = title;
-        this.deadline = deadline;
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
         this.scope = scope;
         this.priority = priority;
     }
 
-    public static Plan create(User user, final String title, final LocalDateTime deadline, final String scope, final Priority priority) {
+    public static Plan create(User user, final String title, final LocalDateTime startDateTime, final LocalDateTime endDateTime, final String scope, final Priority priority) {
         return Plan.builder()
                 .user(user)
                 .title(title)
-                .deadline(deadline)
+                .startDateTime(startDateTime)
+                .endDateTime(endDateTime)
                 .scope(scope)
                 .priority(priority)
                 .build();

--- a/src/main/java/com/miruni/backend/domain/plan/repository/AiPlanRepository.java
+++ b/src/main/java/com/miruni/backend/domain/plan/repository/AiPlanRepository.java
@@ -50,6 +50,7 @@ public interface AiPlanRepository extends JpaRepository<AiPlan, Long> {
     Optional<AiPlan> findByIdAndPlanUserId(Long id, Long userId);
 
     List<AiPlan> findByPlanId(Long planId);
+
 //    boolean existsByPlanUserIdAndScheduledTime(Long userId, LocalTime scheduledTime);
     boolean existsByPlanUserIdAndStartDateTime(Long userId, LocalDateTime startDateTime);
 

--- a/src/main/java/com/miruni/backend/domain/plan/repository/BasicPlanRepository.java
+++ b/src/main/java/com/miruni/backend/domain/plan/repository/BasicPlanRepository.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.time.LocalTime;
 import java.util.Optional;
 
 @Repository
@@ -47,6 +46,7 @@ public interface BasicPlanRepository extends JpaRepository<BasicPlan, Long> {
             @Param("userId") Long userId,
             @Param("date") LocalDate date
     );
+
     //boolean existsByUserIdAndScheduledTime(Long userId, LocalTime scheduledTime);
     //boolean existsByUserIdAndScheduledStartTime(Long userId, LocalTime scheduledTime);
 

--- a/src/main/java/com/miruni/backend/domain/plan/service/AiPlanCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/AiPlanCommandService.java
@@ -23,6 +23,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -37,6 +39,11 @@ public class AiPlanCommandService {
     private final PlanQueryService planQueryService;
     private final ScheduleValidator scheduleValidator;
 
+    private static void checkWithinDeadline(LocalDateTime deadline, LocalDateTime scheduledDate) {
+        if (scheduledDate.isAfter(deadline)) {
+            throw BaseException.type(AiPlanErrorCode.DEADLINE_AFTER);
+        }
+    }
 
     @Transactional
     public Plan savePlan(PlanCreateCommandDto command) {
@@ -45,7 +52,8 @@ public class AiPlanCommandService {
         Plan newPlan = Plan.create(
                 user,
                 command.title(),
-                command.deadline().atStartOfDay(),
+                command.startDateTime(),
+                command.endDateTime(),
                 command.taskRange(),
                 command.priority()
         );
@@ -66,6 +74,7 @@ public class AiPlanCommandService {
                         dto.scheduledDate().atTime(dto.endTime())
                 );
             }
+            scheduleValidator.validateConflict(userId, command.startDateTime(), command.endDateTime());
 
             List<AiPlan> entityToSave = dtoList.stream()
                     .map(dto -> AiPlan.create(
@@ -84,8 +93,6 @@ public class AiPlanCommandService {
             return savedEntity.stream()
                     .map(entity -> AiPlanCreateResponse.fromEntity(entity, plan))
                     .toList();
-
-
         }
         return List.of();
     }
@@ -102,7 +109,11 @@ public class AiPlanCommandService {
         scheduleValidator.validateConflictForAiPlan(command.userId(), aiPlanId,
                 command.scheduledDate().atTime(command.startTime()),
                 command.scheduledDate().atTime(command.endTime()));
+
+        checkWithinDeadline(plan.getEndDateTime(), command.scheduledDate().atTime(command.endTime()));
+
         plan.updateTitle(command.title());
+
         aiPlan.updateDetails(
                 command.subTitle(),
                 command.scheduledDate().atTime(command.startTime()),

--- a/src/main/java/com/miruni/backend/domain/plan/service/AiPlanQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/AiPlanQueryService.java
@@ -8,18 +8,13 @@ import com.miruni.backend.domain.plan.entity.Status;
 import com.miruni.backend.domain.user.service.UserQueryService;
 import com.miruni.backend.global.exception.BaseException;
 import com.miruni.backend.global.exception.CommonErrorCode;
-import com.miruni.backend.domain.plan.entity.AiPlan;
 import com.miruni.backend.domain.plan.exception.AiPlanErrorCode;
 import com.miruni.backend.domain.plan.repository.AiPlanRepository;
-import com.miruni.backend.domain.user.service.UserQueryService;
-import com.miruni.backend.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import java.time.LocalTime;
 
 @Service
 @RequiredArgsConstructor
@@ -69,7 +64,7 @@ public class AiPlanQueryService {
             return AiPlanResponse.of(
                     plan.getId(),
                     plan.getTitle(),
-                    plan.getDeadline().toLocalDate(),
+                    plan.getStartDateTime().toLocalDate(),
                     plan.getScope(),
                     plan.getPriority(),
                     progressRate,

--- a/src/main/java/com/miruni/backend/domain/plan/service/GeminiParser.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/GeminiParser.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.miruni.backend.domain.plan.dto.command.AiPlanCreateCommandDto;
 import com.miruni.backend.domain.plan.dto.response.AiPlanCreateResponse;
-import com.miruni.backend.domain.plan.entity.Plan;
 import com.miruni.backend.domain.plan.exception.AiPlanErrorCode;
 import com.miruni.backend.global.exception.BaseException;
 import org.springframework.stereotype.Component;
@@ -53,7 +52,7 @@ public class GeminiParser {
             return aiSteps.stream()
                     .map(step -> new AiPlanCreateResponse(
                             command.planId(), 1L,
-                            command.title(), command.deadline(), command.taskRange(), command.priority(),
+                            command.title(), command.startDateTime().toLocalDate(), command.scope(), command.priority(),
                             step.scheduledDate(), step.subTitle(), step.expectedDuration(),
                             step.startTime(), step.endTime()
                     ))

--- a/src/main/java/com/miruni/backend/domain/plan/service/GeminiService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/GeminiService.java
@@ -41,7 +41,7 @@ public class GeminiService {
         return false;
     }
 
-    @Cacheable(value = "aiPlans", key = "#command.title + #command.deadline + #command.taskRange", cacheManager = "cacheManager")
+    @Cacheable(value = "aiPlans", key = "#command.title + #command.endDateTime + #command.scope", cacheManager = "cacheManager")
     public Mono<List<AiPlanCreateResponse>> getAiPlanFromApi(AiPlanCreateCommandDto command) {
         String prompt = buildPrompt(command);
         AiRequest aiRequest = AiRequest.fromPrompt(prompt);
@@ -72,16 +72,16 @@ public class GeminiService {
                 
                 Based on the information below, break down the work into detailed sub-tasks.
                 - The number of sub-tasks must be between 2 and 10.
-                - Schedule the dates and times logically leading up to the deadline.
+                - Schedule the dates and times logically between StartDateTime and EndDateTime.
                 
                 The JSON array must consist of objects containing strictly the following keys:
                 - "scheduledDate": (string, "YYYY-MM-DD")
                 - "subTitle": (string, sub-task title)
-                - "expectedDuration": (number, in minutes)        
-                - "startTime": (string, "HH:MM:SS")        
-                - "endTime": (string, "HH:MM:SS")        
+                - "expectedDuration": (number, in minutes)
+                - "startTime": (string, "HH:MM:SS")
+                - "endTime": (string, "HH:MM:SS")
                 
-                Schedule the tasks according to the following "Preferred Time Slot" definitions:
+                [Time Slot Definitions]
                 - RANDOM : Random time
                 - MORNING : 06:00 ~ 09:00
                 - FOCUS_MORNING : 09:00 ~ 12:00
@@ -90,16 +90,26 @@ public class GeminiService {
                 - NIGHT : 22:00 ~ 23:59
                 - DAWN : 00:00 ~ 06:00
                 
+                [Scheduling Rules]
+                1. Try to fit tasks into the 'Preferred Time Slot' if possible.
+                2. If StartDateTime and EndDateTime are on the same day (Single-day Task):
+                   - You MUST schedule all tasks within that single day.
+                   - If the tasks cannot fit into the 'Preferred Time Slot', you are allowed to extend beyond the preferred slot to ensure all tasks are completed within the day.
+                3. If StartDateTime and EndDateTime are different (Multi-day Task):
+                   - Distribute tasks logically across the days within the 'Preferred Time Slot'.
+                4. Chronological Order: The final JSON array MUST be sorted strictly by 'scheduledDate' and 'startTime'. The earliest task must appear first in the array.
+                
                 [Task Information]
                 - Title: %s
-                - Deadline: %s
+                - StartDateTime: %s
+                - EndDateTime: %s
                 - Preferred Time Slot: %s
                 - Scope: %s
                 - Priority: %s
                 - Details: %s
                 """,
-                command.title(), command.deadline(), command.timePeriod(),
-                command.taskRange(), command.priority(), command.detailRequest()
+                command.title(), command.startDateTime(), command.endDateTime(), command.timePeriod(),
+                command.scope(), command.priority(), command.detailRequest()
         );
     }
 

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanCommandService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanCommandService.java
@@ -20,7 +20,6 @@ import com.miruni.backend.domain.plan.repository.PlanRepository;
 import com.miruni.backend.domain.plan.validator.ScheduleValidator;
 import com.miruni.backend.domain.plan.repository.AiPlanRepository;
 import com.miruni.backend.domain.plan.type.PlanType;
-import com.miruni.backend.domain.plan.validator.ScheduleValidator;
 import com.miruni.backend.domain.user.entity.User;
 import com.miruni.backend.domain.user.service.UserQueryService;
 import com.miruni.backend.global.exception.BaseException;
@@ -136,7 +135,7 @@ public class PlanCommandService {
                     throw BaseException.type(AiPlanErrorCode.AI_PLAN_NOT_FOUND);
                 }
 
-                checkWithinDeadline(plan.getDeadline().toLocalDate(), dto.scheduledDate());
+                checkWithinDeadline(plan.getStartDateTime().toLocalDate(), dto.scheduledDate());
                 checkExpectedDuration(dto.startTime(), dto.endTime(), dto.expectedDuration());
                 scheduleValidator.validateConflictForAiPlan(command.userId(), dto.aiPlanId(),
                         dto.scheduledDate().atTime(dto.startTime()),
@@ -164,7 +163,7 @@ public class PlanCommandService {
                         aiPlan.getStatus()
                 )).toList();
 
-        return AiPlanResponse.of(command.planId(), plan.getTitle(), plan.getDeadline().toLocalDate(), plan.getScope(), plan.getPriority(), plan.getProgressRate(), savedDtos);
+        return AiPlanResponse.of(command.planId(), plan.getTitle(), plan.getStartDateTime().toLocalDate(), plan.getScope(), plan.getPriority(), plan.getProgressRate(), savedDtos);
     }
 
     public PlanStartResponse startPlan(PlanStartRequest request) {

--- a/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/com/miruni/backend/domain/plan/service/PlanQueryService.java
@@ -1,15 +1,11 @@
 package com.miruni.backend.domain.plan.service;
 
-import com.miruni.backend.domain.plan.dto.command.PlanDurationCommand;
 import com.miruni.backend.domain.plan.dto.response.*;
 import com.miruni.backend.domain.plan.dto.response.PlanPreviewDto;
 import com.miruni.backend.domain.plan.dto.response.PlanReadResponse;
-import com.miruni.backend.domain.plan.dto.command.PlanDurationCommand;
-import com.miruni.backend.domain.plan.dto.response.PlanDurationResponse;
 import com.miruni.backend.domain.plan.dto.response.DailyPlanResponse;
 import com.miruni.backend.domain.plan.dto.response.MonthlyPlanResponse;
 import com.miruni.backend.domain.plan.dto.response.PlanDetailResponse;
-import com.miruni.backend.domain.plan.dto.response.PlanDurationResponse;
 import com.miruni.backend.domain.plan.entity.AiPlan;
 import com.miruni.backend.domain.plan.entity.Plan;
 import com.miruni.backend.domain.plan.entity.BasicPlan;
@@ -20,7 +16,6 @@ import com.miruni.backend.domain.user.entity.User;
 import com.miruni.backend.domain.user.service.UserQueryService;
 import com.miruni.backend.domain.plan.exception.AiPlanErrorCode;
 import com.miruni.backend.domain.plan.exception.BasicPlanErrorCode;
-import com.miruni.backend.domain.plan.exception.PlanErrorCode;
 import com.miruni.backend.domain.plan.repository.AiPlanRepository;
 import com.miruni.backend.domain.plan.repository.BasicPlanRepository;
 import com.miruni.backend.domain.plan.type.PlanType;
@@ -34,10 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.LocalDateTime;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -88,8 +81,7 @@ public class PlanQueryService {
     }
 
     public PlanHomeResponse getPlanHome(Long userId) {
-//        LocalDate today = LocalDate.now();
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate today = LocalDate.now();
 
         List<DailyPlanResponse.DailyPlanItemResponse> allPlans =
                 Stream.concat(


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #46 

## 📝 작업 내용
- ai 플래닝 시, 단일/기간 정책사항 반영하여 plan 엔티티 수정과 dto 수정
- ai 일정 낱개 수정 시, 마감기한 이전 날짜 등록 시 커스텀 에러 처리

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
